### PR TITLE
Get rid of hard to distinguish characters in password generation(e.g. l/1 0/O)

### DIFF
--- a/pycroft/helpers/user.py
+++ b/pycroft/helpers/user.py
@@ -12,6 +12,7 @@ crypt_context = ldap_context.copy(
 
 
 def generate_password(length):
+    #without hard to distinguish characters l/1 0/O
     charset = "abcdefghijkmnopqrstuvwxyz!$%&()=.," \
               ":;-_#+23456789ABCDEFGHIJKLMNPQRSTUVWXYZ"
     return passlib.utils.generate_password(length, charset)

--- a/pycroft/helpers/user.py
+++ b/pycroft/helpers/user.py
@@ -12,8 +12,8 @@ crypt_context = ldap_context.copy(
 
 
 def generate_password(length):
-    charset = "abcdefghijklmnopqrstuvwxyz!$%&()=.," \
-              ":;-_#+1234567890ABCDEFGHIJKLMNOPQRSTUVWXYZ"
+    charset = "abcdefghijkmnopqrstuvwxyz!$%&()=.," \
+              ":;-_#+23456789ABCDEFGHIJKLMNPQRSTUVWXYZ"
     return passlib.utils.generate_password(length, charset)
 
 


### PR DESCRIPTION
At least in Courier, which my form was printed in, those characters are almost indistinguishable