### PR TITLE
Reconstruct customly small membership intervals

### DIFF
--- a/legacy/reconstruct_memberships.py
+++ b/legacy/reconstruct_memberships.py
@@ -41,26 +41,10 @@ def interval_count(interval_list):
     return counter
 
 
-def nextmonth(original_date):
-    return (original_date.replace(day=1) + timedelta(days=32)).replace(day=1)
-
-
-def prevmonth(original_date):
-    return (original_date.replace(day=1) - timedelta(days=1)).replace(day=1)
-
-
-def advance_some_months(original_date, months):
-    current_date = original_date
-    for _ in range(months):
-        current_date = nextmonth(current_date)
-    return current_date
-
-
-def recede_some_months(original_date, months):
-    current_date = original_date
-    for _ in range(months):
-        current_date = prevmonth(current_date)
-    return current_date
+def monthdelta(date, delta):
+     new_month = (date.month + delta - 1) % 12 + 1
+     year_delta = (date.month + delta - new_month) / 12
+     return date.replace(year=date.year+year_delta, month=new_month, day=1)
 
 
 def sem_to_interval(s):
@@ -234,11 +218,11 @@ def membership_from_fees(user, semesters, n):
                     cropped_interval = uncropped_interval
                 elif touching_below:
                     log.debug("Membership intervals touch below, cropping above.")
-                    new_upper_bound = recede_some_months(uncropped_interval.end, num_months)
+                    new_upper_bound = monthdelta(uncropped_interval.end, -num_months)
                     cropped_interval = closedopen(uncropped_interval.begin, new_upper_bound)
                 elif touching_above:
                     log.debug("Membership intervals touch above, cropping below.")
-                    new_lower_bound = advance_some_months(uncropped_interval.begin, num_months)
+                    new_lower_bound = monthdelta(uncropped_interval.begin, num_months)
                     cropped_interval = closedopen(new_lower_bound, uncropped_interval.end)
                 else:
                     log.debug("max below / min above: %s / %s",

--- a/legacy/translate.py
+++ b/legacy/translate.py
@@ -638,6 +638,17 @@ def reconstruct_memberships(data, resources):
             gname_duration = defaultdict(IntervalSet)
             gname_duration["member"], gname_duration["away"] = membership_from_fees(u, semesters, n)
 
+
+            # if the membership could be reconstructed ending at the
+            # beginning of the current month (last fee), delete the
+            # ending and make it unbounded
+            latest_membership_end = max(gname_duration['member']).end \
+                                    if gname_duration['member'] else None
+
+            if latest_membership_end is not None and \
+                   latest_membership_end.replace(day=1) == date.today().replace(day=1):
+                gname_duration['member'] += IntervalSet(closedopen(latest_membership_end, None))
+
             for gname in status_groups_map[_u.status_id]: # current memberships
                 gname_duration[gname] += IntervalSet(
                     closedopen(datetime.now().date(), None))


### PR DESCRIPTION
Sometimes, instead of the regular membership fee, a smaller one has been
booked by the head of finance, to compensate for the smaller interval of
membership.  In most cases, this can be used to reconstruct the
membership intervals in higher precisions (instead of throwing an error
due to fee amount inconsistencies).