### PR TITLE
Set flask debug flag early to make template reloading work

### DIFF
--- a/server_run.py
+++ b/server_run.py
@@ -26,7 +26,7 @@ def server_run(args):
           " from what is given below."
           " It is probably http://0.0.0.0:5001")
 
-    app = make_app()
+    app = make_app(args.debug)
     @app.before_request
     def get_time():
         g.request_time = time()

--- a/web/app.py
+++ b/web/app.py
@@ -55,12 +55,13 @@ class PycroftFlask(Flask):
                 self.logger.debug("Config key %s successfuly read from environment", key)
 
 
-def make_app():
+def make_app(debug=False):
     """  Create and configure the main? Flask app object
 
     :return: The fully configured app object
     """
     app = PycroftFlask(__name__)
+    app.debug = debug
 
     #initialization code
     login_manager.init_app(app)


### PR DESCRIPTION
app.create_jinja_environment evaluates app.debug to decide whether it
should enable template auto reloading or not. Passing the debug flag
to app.run is not helping, because at this time
app.create_jinja_environment already has been called.