### PR TITLE
WIP: Views and rules

### DIFF
--- a/pycroft/lib/user.py
+++ b/pycroft/lib/user.py
@@ -364,19 +364,13 @@ def traffic_events_expr():
         literal("credit").label('type')]),
 
         select([(-TrafficVolume.amount).label('amount'),
-                Host.owner_id.label('user_id'),
+                TrafficVolume.user_id,
                 TrafficVolume.timestamp,
                 literal("debit").label('type')]
-               ).select_from(
-            TrafficVolume.__table__.join(
-                IP.__table__
-            ).join(
-                Interface.__table__
-            ).join(
-                Host.__table__)),
+               ),
 
         select([TrafficBalance.amount,
-                TrafficBalance.user_id.label('user_id'),
+                TrafficBalance.user_id,
                 TrafficBalance.timestamp,
                 literal("balance").label('type')]  # ).select_from(
                # .__table__.outerjoin(TrafficBalance)

--- a/pycroft/model/ddl.py
+++ b/pycroft/model/ddl.py
@@ -123,18 +123,23 @@ def visit_drop_function(element, compiler, **kw):
 
 
 class ConstraintTrigger(schema.DDLElement):
-    def __init__(self, name, table, events, function_call):
+    def __init__(self, name, table, events, function_call,
+                 deferrable=False, initially_deferred=False):
         """
         Construct a constraint trigger
         :param str name: Name of the trigger
         :param table: Table the trigger is for
         :param iterable[str] events: list of events (INSERT, UPDATE, DELETE)
         :param str function_call: call of the trigger function
+        :param deferrable: Constraint can be deferred
+        :param initially_deferred: Constraint is set to deferred
         """
         self.name = name
         self.table = table
         self.events = events
         self.function_call = function_call
+        self.deferrable = deferrable
+        self.initially_deferred = initially_deferred
 
 
 class CreateConstraintTrigger(schema.DDLElement):
@@ -166,9 +171,12 @@ def create_add_constraint_trigger(element, compiler, **kw):
     """
     trigger = element.constraint_trigger
     events = ' OR '.join(trigger.events)
+    opt_deferrable = 'DEFERRABLE' if trigger.deferrable else None
+    opt_initially_deferred = ('INITIALLY DEFERRED' if trigger.initially_deferred
+                              else None)
     return _join_tokens(
         "CREATE CONSTRAINT TRIGGER", trigger.name, 'AFTER', events, 'ON',
-        trigger.table.name, "DEFERRABLE INITIALLY DEFERRED",
+        trigger.table.name, opt_deferrable, opt_initially_deferred,
         "FOR EACH ROW EXECUTE PROCEDURE", trigger.function_call)
 
 

--- a/pycroft/model/ddl.py
+++ b/pycroft/model/ddl.py
@@ -3,9 +3,8 @@
 # the Apache License, Version 2.0. See the LICENSE file for details.
 import inspect
 
-from sqlalchemy import event
+from sqlalchemy import event as sqla_event, schema
 from sqlalchemy.ext.compiler import compiles
-from sqlalchemy import schema
 
 
 def _join_tokens(*tokens) -> str:
@@ -223,9 +222,9 @@ class DDLManager(object):
 
     def register(self):
         for target, create_ddl, drop_ddl in self.objects:
-            event.listen(target, 'after_create', create_ddl)
+            sqla_event.listen(target, 'after_create', create_ddl)
         for target, create_ddl, drop_ddl in reversed(self.objects):
-            event.listen(target, 'before_drop', drop_ddl)
+            sqla_event.listen(target, 'before_drop', drop_ddl)
 
 
 # TODO: HERE is the location to add other views (radius, user for pmacct)

--- a/pycroft/model/ddl.py
+++ b/pycroft/model/ddl.py
@@ -99,10 +99,10 @@ class DropFunction(schema.DDLElement):
     """
     on = 'postgresql'
 
-    def __init__(self, func, if_exists=False):
+    def __init__(self, func, if_exists=False, cascade=False):
         self.function = func
         self.if_exists = if_exists
-
+        self.cascade = cascade
 
 # noinspection PyUnusedLocal
 @compiles(CreateFunction, 'postgresql')

--- a/pycroft/model/ddl.py
+++ b/pycroft/model/ddl.py
@@ -117,8 +117,9 @@ def visit_drop_function(element, compiler, **kw):
     Compile a DROP FUNCTION DDL statement for PostgreSQL
     """
     opt_if_exists = "IF EXISTS" if element.if_exists else None
+    opt_drop_behavior = "CASCADE" if element.cascade else None
     return _join_tokens("DROP FUNCTION", opt_if_exists,
-                        element.function.name)
+                        element.function.name, opt_drop_behavior)
 
 
 class ConstraintTrigger(schema.DDLElement):
@@ -179,9 +180,10 @@ def visit_drop_trigger(element, compiler, **kw):
     """
     trigger = element.trigger
     opt_if_exists = "IF EXISTS" if element.if_exists else None
+    opt_drop_behavior = "CASCADE" if element.cascade else None
     return _join_tokens(
-        "DROP TRIGGER", opt_if_exists, trigger.name, "ON", trigger.table.name)
-    )
+        "DROP TRIGGER", opt_if_exists, trigger.name, "ON", trigger.table.name,
+        opt_drop_behavior)
 
 
 class DDLManager(object):

--- a/pycroft/model/ddl.py
+++ b/pycroft/model/ddl.py
@@ -2,15 +2,15 @@
 # This file is part of the Pycroft project and licensed under the terms of
 # the Apache License, Version 2.0. See the LICENSE file for details.
 import inspect
+from collections import Iterable
 from functools import partial
-from typing import Dict, Iterable, Optional, Sequence
 
 from sqlalchemy import event as sqla_event, schema
 from sqlalchemy.ext.compiler import compiles
 from sqlalchemy.sql import ClauseElement
 
 
-def _join_tokens(*tokens) -> str:
+def _join_tokens(*tokens):
     """
     Join all elements that are not None
     :param tokens:
@@ -160,7 +160,7 @@ class CreateRule(schema.DDLElement):
     """
     on = 'postgresql'
 
-    def __init__(self, rule: Rule, or_replace: bool = False):
+    def __init__(self, rule, or_replace=False):
         self.rule = rule
         self.or_replace = or_replace
 
@@ -171,8 +171,7 @@ class DropRule(schema.DDLElement):
     """
     on = 'postgresql'
 
-    def __init__(self, rule: Rule, if_exists: bool = False,
-                 cascade: bool = False):
+    def __init__(self, rule, if_exists=False, cascade=False):
         """
         :param rule:
         :param if_exists:
@@ -304,9 +303,9 @@ def visit_drop_trigger(element, compiler, **kw):
 
 class View(schema.DDLElement):
     def __init__(self, name, query,
-                 column_names: Optional[Sequence[str]] = None,
-                 temporary: bool = False,
-                 view_options: Optional[Dict[str, str]] = None,
+                 column_names=None,
+                 temporary=False,
+                 view_options=None,
                  check_option=None):
         self.name = name
         self.query = query
@@ -327,13 +326,13 @@ class View(schema.DDLElement):
 
 
 class CreateView(schema.DDLElement):
-    def __init__(self, view, or_replace: bool = False):
+    def __init__(self, view, or_replace=False):
         self.view = view
         self.or_replace = or_replace
 
 
 class DropView(schema.DDLElement):
-    def __init__(self, view, if_exists: bool = False, cascade: bool = False):
+    def __init__(self, view, if_exists=False, cascade=False):
         self.view = view
         self.if_exists = if_exists
         self.cascade = cascade

--- a/pycroft/model/ddl.py
+++ b/pycroft/model/ddl.py
@@ -124,7 +124,7 @@ def visit_drop_function(element, compiler, **kw):
 
 class ConstraintTrigger(schema.DDLElement):
     def __init__(self, name, table, events, function_call,
-                 deferrable=False, initially_deferred=False):
+                 deferrable: bool = False, initially_deferred: bool = False):
         """
         Construct a constraint trigger
         :param str name: Name of the trigger
@@ -148,7 +148,7 @@ class CreateConstraintTrigger(schema.DDLElement):
     """
     on = 'postgresql'
 
-    def __init__(self, constraint_trigger):
+    def __init__(self, constraint_trigger: ConstraintTrigger):
         self.constraint_trigger = constraint_trigger
 
 
@@ -158,7 +158,7 @@ class DropTrigger(schema.DDLElement):
     """
     on = 'postgresql'
 
-    def __init__(self, trigger, if_exists=False):
+    def __init__(self, trigger: ConstraintTrigger, if_exists: bool = False):
         self.trigger = trigger
         self.if_exists = if_exists
 

--- a/pycroft/model/ddl.py
+++ b/pycroft/model/ddl.py
@@ -283,9 +283,10 @@ class DropTrigger(schema.DDLElement):
     """
     on = 'postgresql'
 
-    def __init__(self, trigger, if_exists=False):
+    def __init__(self, trigger, if_exists=False, cascade=False):
         self.trigger = trigger
         self.if_exists = if_exists
+        self.cascade = cascade
 
 
 # noinspection PyUnusedLocal

--- a/pycroft/model/ddl.py
+++ b/pycroft/model/ddl.py
@@ -33,9 +33,11 @@ def visit_drop_constraint(drop_constraint, compiler, **kw):
     constraint = drop_constraint.element
     opt_if_exists = 'IF EXISTS' if drop_constraint.if_exists else None
     opt_drop_behavior = 'CASCADE' if drop_constraint.cascade else None
+    table_name = compiler.preparer.format_table(constraint.table)
+    constraint_name = compiler.preparer.quote(constraint.name)
     return _join_tokens(
-        "ALTER TABLE", constraint.table.name, "DROP CONSTRAINT", opt_if_exists,
-        constraint.name, opt_drop_behavior)
+        "ALTER TABLE", table_name, "DROP CONSTRAINT", opt_if_exists,
+        constraint_name, opt_drop_behavior)
 
 
 class Function(schema.DDLElement):
@@ -104,8 +106,9 @@ def visit_create_function(element, compiler, **kw):
     leakproof = "LEAKPROOF" if func.leakproof else None
     quoted_definition = "${quote_tag}$\n{definition}\n${quote_tag}$".format(
         quote_tag=func.quote_tag, definition=func.definition)
+    function_name = compiler.preparer.quote(func.name)
     return _join_tokens(
-        "CREATE", opt_or_replace, "FUNCTION", func.name, "RETURNS",
+        "CREATE", opt_or_replace, "FUNCTION", function_name, "RETURNS",
         func.rtype, volatility, strictness, leakproof,
         quoted_definition)
 
@@ -118,8 +121,9 @@ def visit_drop_function(element, compiler, **kw):
     """
     opt_if_exists = "IF EXISTS" if element.if_exists else None
     opt_drop_behavior = "CASCADE" if element.cascade else None
+    function_name = compiler.preparer.quote(element.function.name)
     return _join_tokens("DROP FUNCTION", opt_if_exists,
-                        element.function.name, opt_drop_behavior)
+                        function_name, opt_drop_behavior)
 
 
 class ConstraintTrigger(schema.DDLElement):
@@ -174,9 +178,11 @@ def create_add_constraint_trigger(element, compiler, **kw):
     opt_deferrable = 'DEFERRABLE' if trigger.deferrable else None
     opt_initially_deferred = ('INITIALLY DEFERRED' if trigger.initially_deferred
                               else None)
+    trigger_name = compiler.preparer.quote(trigger.name)
+    table_name = compiler.preparer.format_table(trigger.table)
     return _join_tokens(
-        "CREATE CONSTRAINT TRIGGER", trigger.name, 'AFTER', events, 'ON',
-        trigger.table.name, opt_deferrable, opt_initially_deferred,
+        "CREATE CONSTRAINT TRIGGER", trigger_name, 'AFTER', events, 'ON',
+        table_name, opt_deferrable, opt_initially_deferred,
         "FOR EACH ROW EXECUTE PROCEDURE", trigger.function_call)
 
 
@@ -189,8 +195,10 @@ def visit_drop_trigger(element, compiler, **kw):
     trigger = element.trigger
     opt_if_exists = "IF EXISTS" if element.if_exists else None
     opt_drop_behavior = "CASCADE" if element.cascade else None
+    trigger_name = compiler.preparer.quote(trigger.name)
+    table_name = compiler.preparer.format_table(trigger.table)
     return _join_tokens(
-        "DROP TRIGGER", opt_if_exists, trigger.name, "ON", trigger.table.name,
+        "DROP TRIGGER", opt_if_exists, trigger_name, "ON", table_name,
         opt_drop_behavior)
 
 

--- a/pycroft/model/ddl.py
+++ b/pycroft/model/ddl.py
@@ -19,6 +19,7 @@ class DropConstraint(schema.DropConstraint):
         self.cascade = cascade
 
 
+# noinspection PyUnusedLocal
 @compiles(DropConstraint, 'postgresql')
 def visit_drop_constraint(drop_constraint, compiler, **kw):
     constraint = drop_constraint.element
@@ -82,6 +83,7 @@ class DropFunction(schema.DDLElement):
         self.function = func
 
 
+# noinspection PyUnusedLocal
 @compiles(CreateFunction, 'postgresql')
 def visit_create_function(element, compiler, **kw):
     """
@@ -102,6 +104,7 @@ def visit_create_function(element, compiler, **kw):
     )
 
 
+# noinspection PyUnusedLocal
 @compiles(DropFunction, 'postgresql')
 def visit_drop_function(element, compiler, **kw):
     """
@@ -145,6 +148,7 @@ class DropTrigger(schema.DDLElement):
         self.trigger = trigger
 
 
+# noinspection PyUnusedLocal
 @compiles(CreateConstraintTrigger, 'postgresql')
 def create_add_constraint_trigger(element, compiler, **kw):
     """
@@ -158,6 +162,7 @@ def create_add_constraint_trigger(element, compiler, **kw):
         table=trigger.table.name, function=trigger.function_call)
 
 
+# noinspection PyUnusedLocal
 @compiles(DropTrigger, 'postgresql')
 def visit_drop_trigger(element, compiler, **kw):
     """

--- a/pycroft/model/ddl.py
+++ b/pycroft/model/ddl.py
@@ -225,7 +225,7 @@ def visit_drop_rule(element, compiler, **kw):
 
 class ConstraintTrigger(schema.DDLElement):
     def __init__(self, name, table, events, function_call,
-                 deferrable: bool = False, initially_deferred: bool = False):
+                 deferrable=False, initially_deferred=False):
         """
         Construct a constraint trigger
         :param str name: Name of the trigger
@@ -252,7 +252,7 @@ class CreateConstraintTrigger(schema.DDLElement):
     """
     on = 'postgresql'
 
-    def __init__(self, constraint_trigger: ConstraintTrigger):
+    def __init__(self, constraint_trigger):
         self.constraint_trigger = constraint_trigger
 
 
@@ -262,7 +262,7 @@ class DropTrigger(schema.DDLElement):
     """
     on = 'postgresql'
 
-    def __init__(self, trigger: ConstraintTrigger, if_exists: bool = False):
+    def __init__(self, trigger, if_exists=False):
         self.trigger = trigger
         self.if_exists = if_exists
 

--- a/pycroft/model/ddl.py
+++ b/pycroft/model/ddl.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2015 The Pycroft Authors. See the AUTHORS file.
+# Copyright (c) 2015-2017 The Pycroft Authors. See the AUTHORS file.
 # This file is part of the Pycroft project and licensed under the terms of
 # the Apache License, Version 2.0. See the LICENSE file for details.
 import inspect

--- a/pycroft/model/ddl.py
+++ b/pycroft/model/ddl.py
@@ -99,13 +99,14 @@ def visit_create_function(element, compiler, **kw):
     """
     func = element.function
     opt_or_replace = 'OR REPLACE' if element.or_replace else None
+    volatility = func.volatility.upper()
     strictness = "STRICT" if func.strict else None
     leakproof = "LEAKPROOF" if func.leakproof else None
     quoted_definition = "${quote_tag}$\n{definition}\n${quote_tag}$".format(
         quote_tag=func.quote_tag, definition=func.definition)
     return _join_tokens(
         "CREATE", opt_or_replace, "FUNCTION", func.name, "RETURNS",
-        func.rtype, func.volatility, strictness, leakproof,
+        func.rtype, volatility, strictness, leakproof,
         quoted_definition)
 
 

--- a/pycroft/model/ddl.py
+++ b/pycroft/model/ddl.py
@@ -2,7 +2,7 @@
 # This file is part of the Pycroft project and licensed under the terms of
 # the Apache License, Version 2.0. See the LICENSE file for details.
 import inspect
-from collections import Iterable
+from collections import Iterable, OrderedDict
 from functools import partial
 
 from sqlalchemy import event as sqla_event, schema
@@ -329,14 +329,25 @@ class View(schema.DDLElement):
                  temporary=False,
                  view_options=None,
                  check_option=None):
+        """DDL Element representing a VIEW
+
+        :param name: The name of the view
+        :param query: the query it represents
+        :param column_names:
+        :param temporary:
+        :param view_options: Must be something that can be passed to
+            OrderedDict, so a simple dict suffices.
+        :param check_option: Must be one of ``None``, ``'local'``,
+            ``'cascaded'``.
+        """
         self.name = name
         self.query = query
         self.temporary = temporary
         self.column_names = column_names
         if view_options is None:
-            view_options = {}
+            view_options = OrderedDict()
         else:
-            view_options = dict(view_options)
+            view_options = OrderedDict(view_options)
         self.view_options = view_options
         if check_option not in (None, 'local', 'cascaded'):
             raise ValueError("check_option must be either None, 'local', or "

--- a/pycroft/model/ddl.py
+++ b/pycroft/model/ddl.py
@@ -99,7 +99,7 @@ def visit_create_function(element, compiler, **kw):
     """
     func = element.function
     opt_or_replace = 'OR REPLACE' if element.or_replace else None
-    strictness = "STRICT" if func.strict else "CALLED ON NULL INPUT"
+    strictness = "STRICT" if func.strict else None
     leakproof = "LEAKPROOF" if func.leakproof else None
     quoted_definition = "${quote_tag}$\n{definition}\n${quote_tag}$".format(
         quote_tag=func.quote_tag, definition=func.definition)

--- a/pycroft/model/ddl.py
+++ b/pycroft/model/ddl.py
@@ -143,6 +143,9 @@ class ConstraintTrigger(schema.DDLElement):
         self.events = events
         self.function_call = function_call
         self.deferrable = deferrable
+        if not deferrable and initially_deferred:
+            raise ValueError("Constraint declared INITIALLY DEFERRED must be "
+                             "DEFERRABLE.")
         self.initially_deferred = initially_deferred
 
 

--- a/pycroft/model/ddl.py
+++ b/pycroft/model/ddl.py
@@ -68,8 +68,8 @@ class CreateFunction(schema.DDLElement):
     """
     on = 'postgresql'
 
-    def __init__(self, function):
-        self.function = function
+    def __init__(self, func):
+        self.function = func
 
 
 class DropFunction(schema.DDLElement):
@@ -78,8 +78,8 @@ class DropFunction(schema.DDLElement):
     """
     on = 'postgresql'
 
-    def __init__(self, function):
-        self.function = function
+    def __init__(self, func):
+        self.function = func
 
 
 @compiles(CreateFunction, 'postgresql')
@@ -87,18 +87,18 @@ def visit_create_function(element, compiler, **kw):
     """
     Compile a CREATE FUNCTION DDL statement for PostgreSQL
     """
-    function = element.function
+    func = element.function
     return (
         "CREATE OR REPLACE FUNCTION {name} RETURNS {rtype} {volatility} "
         "{strict} {leakproof} LANGUAGE {language} AS "
         "${quote_tag}$\n{definition}\n${quote_tag}$"
     ).format(
-        name=function.name, rtype=function.rtype,
-        volatility=function.volatility,
-        strict='STRICT' if function.strict else 'CALLED ON NULL INPUT',
-        language=function.language, definition=function.definition,
-        leakproof='LEAKPROOF' if function.leakproof else '',
-        quote_tag=function.quote_tag,
+        name=func.name, rtype=func.rtype,
+        volatility=func.volatility,
+        strict='STRICT' if func.strict else 'CALLED ON NULL INPUT',
+        language=function.language, definition=func.definition,
+        leakproof='LEAKPROOF' if func.leakproof else '',
+        quote_tag=func.quote_tag,
     )
 
 
@@ -188,8 +188,8 @@ class DDLManager(object):
         self.add(table, schema.AddConstraint(constraint),
                  DropConstraint(constraint, if_exists=True), dialect=dialect)
 
-    def add_function(self, table, function, dialect=None):
-        self.add(table, CreateFunction(function), DropFunction(function),
+    def add_function(self, table, func, dialect=None):
+        self.add(table, CreateFunction(func), DropFunction(func),
                  dialect=dialect)
 
     def add_constraint_trigger(self, table, constraint_trigger, dialect=None):

--- a/pycroft/model/finance.py
+++ b/pycroft/model/finance.py
@@ -167,7 +167,8 @@ manager.add_constraint_trigger(
     ddl.ConstraintTrigger(
         'split_check_transaction_balanced_trigger',
         Split.__table__, ('INSERT', 'UPDATE', 'DELETE'),
-        'split_check_transaction_balanced()'
+        'split_check_transaction_balanced()',
+        deferrable=True, initially_deferred=True,
     )
 )
 
@@ -319,7 +320,8 @@ manager.add_constraint_trigger(
         'bank_account_activity_matches_referenced_split_trigger',
         BankAccountActivity.__table__,
         ('INSERT', 'UPDATE', 'DELETE'),
-        'bank_account_activity_matches_referenced_split()'
+        'bank_account_activity_matches_referenced_split()',
+        deferrable=True, initially_deferred=True,
     )
 )
 

--- a/pycroft/model/finance.py
+++ b/pycroft/model/finance.py
@@ -85,7 +85,7 @@ class Account(IntegerIdModel):
 manager.add_function(
     Account.__table__,
     ddl.Function(
-        'account_is_type(integer, account_type)', 'boolean',
+        'account_is_type', ['integer', 'account_type'], 'boolean',
         "SELECT type = $2 FROM account WHERE id = $1 ",
         volatility='stable', strict=True,
     )
@@ -135,7 +135,7 @@ class Split(IntegerIdModel):
 manager.add_function(
     Split.__table__,
     ddl.Function(
-        'split_check_transaction_balanced()', 'trigger',
+        'split_check_transaction_balanced', [], 'trigger',
         """
         DECLARE
           s split;
@@ -281,7 +281,7 @@ manager.add_constraint(
 manager.add_function(
     BankAccountActivity.__table__,
     ddl.Function(
-        'bank_account_activity_matches_referenced_split()',
+        'bank_account_activity_matches_referenced_split', [],
         'trigger',
         """
         DECLARE

--- a/pycroft/model/traffic.py
+++ b/pycroft/model/traffic.py
@@ -28,7 +28,7 @@ class TrafficEvent(object):
 
 
 class TrafficVolume(TrafficEvent, IntegerIdModel):
-    type = Column(Enum("IN", "OUT", name="traffic_direction"),
+    type = Column(Enum("Ingress", "Egress", name="traffic_direction"),
                   nullable=False)
     ip_id = Column(Integer, ForeignKey(IP.id, ondelete="CASCADE"),
                    nullable=False)

--- a/pycroft/model/traffic.py
+++ b/pycroft/model/traffic.py
@@ -28,7 +28,7 @@ class TrafficEvent(object):
 
 
 class TrafficVolume(TrafficEvent, IntegerIdModel):
-    type = Column(Enum("IN", "OUT", name="traffic_types"),
+    type = Column(Enum("IN", "OUT", name="traffic_direction"),
                   nullable=False)
     ip_id = Column(Integer, ForeignKey(IP.id, ondelete="CASCADE"),
                    nullable=False)

--- a/pycroft/model/traffic.py
+++ b/pycroft/model/traffic.py
@@ -40,6 +40,8 @@ class TrafficVolume(TrafficEvent, IntegerIdModel):
                         backref=backref("traffic_volumes",
                                         cascade="all, delete-orphan"),
                         uselist=False)
+    packets = Column(Integer, CheckConstraint('amount >= 0'),
+                     nullable=False)
 
 
 class TrafficCredit(TrafficEvent, IntegerIdModel):

--- a/pycroft/model/traffic.py
+++ b/pycroft/model/traffic.py
@@ -69,11 +69,12 @@ ddl.add_rule(
     PmacctTrafficEgress.__table__,
     Rule("pmacct_traffic_egress_insert", PmacctTrafficEgress.__table__, "INSERT",
          """
-         INSERT INTO traffic_volume (type, ip_id, "timestamp", amount, user_id)
+         INSERT INTO traffic_volume (type, ip_id, "timestamp", amount, packets, user_id)
          SELECT 'Egress',
              ip.id,
              new.stamp_inserted,
              new.bytes,
+             new.packets,
              host.owner_id
             FROM ip
               JOIN interface ON ip.interface_id = interface.id
@@ -98,11 +99,12 @@ ddl.add_rule(
     PmacctTrafficIngress.__table__,
     Rule("pmacct_traffic_ingress_insert", PmacctTrafficIngress.__table__, "INSERT",
          """
-         INSERT INTO traffic_volume (type, ip_id, "timestamp", amount, user_id)
+         INSERT INTO traffic_volume (type, ip_id, "timestamp", amount, packets, user_id)
          SELECT 'Ingress',
              ip.id,
              new.stamp_inserted,
              new.bytes,
+             new.packets,
              host.owner_id
             FROM ip
               JOIN interface ON ip.interface_id = interface.id

--- a/pycroft/model/traffic.py
+++ b/pycroft/model/traffic.py
@@ -2,14 +2,20 @@
 # Copyright (c) 2015 The Pycroft Authors. See the AUTHORS file.
 # This file is part of the Pycroft project and licensed under the terms of
 # the Apache License, Version 2.0. See the LICENSE file for details.
-from sqlalchemy import Column, ForeignKey, CheckConstraint
+from sqlalchemy import Column, ForeignKey, CheckConstraint, PrimaryKeyConstraint
 from sqlalchemy.orm import relationship, backref
+from sqlalchemy.sql import Insert
 from sqlalchemy.types import BigInteger, Enum, Integer, DateTime
 
 from pycroft.model.base import ModelBase, IntegerIdModel
+from pycroft.model.ddl import DDLManager, Rule
+from pycroft.model.types import IPAddress
 from pycroft.model.user import User
 from pycroft.model.functions import utcnow
 from pycroft.model.host import IP
+
+
+ddl = DDLManager()
 
 
 class TrafficBalance(ModelBase):
@@ -42,6 +48,46 @@ class TrafficVolume(TrafficEvent, IntegerIdModel):
                         uselist=False)
     packets = Column(Integer, CheckConstraint('amount >= 0'),
                      nullable=False)
+
+
+class PmacctTable(ModelBase):
+    __abstract__ = True
+    packets = Column(BigInteger, nullable=False)
+    bytes = Column(BigInteger, nullable=False)
+    stamp_inserted = Column(DateTime(timezone=True), nullable=False)
+    stamp_updated = Column(DateTime(timezone=True))
+
+
+class PmacctTrafficEgress(PmacctTable):
+    ip_src = Column(IPAddress, nullable=False)
+    __table_args__ = (
+        PrimaryKeyConstraint('ip_src', 'stamp_inserted'),
+    )
+
+
+"""
+INSERT INTO traffic_volume (type, ip_id, "timestamp", amount, user_id)  SELECT 'IN',
+            ip.id,
+            new.stamp_inserted,
+            new.bytes,
+            host.owner_id
+           FROM ip
+             JOIN interface ON ip.interface_id = interface.id
+             JOIN host ON interface.host_id = host.id
+          WHERE new.ip_dst = ip.address
+"""
+
+ddl.add_rule(
+    PmacctTrafficEgress,
+    Rule("pmacct_traffic_egress_insert", PmacctTrafficEgress, "INSERT",
+         Insert(TrafficVolume.__table__, {}), do_instead=True))
+
+
+class PmacctTrafficIngress(PmacctTable):
+    ip_dst = Column(IPAddress, nullable=False)
+    __table_args__ = (
+        PrimaryKeyConstraint('ip_dst', 'stamp_inserted'),
+    )
 
 
 class TrafficCredit(TrafficEvent, IntegerIdModel):

--- a/pycroft/model/traffic.py
+++ b/pycroft/model/traffic.py
@@ -34,12 +34,11 @@ class TrafficVolume(TrafficEvent, IntegerIdModel):
                    nullable=False)
     ip = relationship(IP, backref=backref("traffic_volumes",
                                           cascade="all, delete-orphan"))
-
+    user_id = Column(Integer, ForeignKey(User.id, ondelete='CASCADE'),
+                     nullable=True)
     user = relationship(User,
-                        secondary="join(Host, Interface,"
-                                  "Interface.host_id == Host.id).join(IP)",
-                        backref="traffic_volumes",
-                        viewonly=True,  # cascade via ip
+                        backref=backref("traffic_volumes",
+                                        cascade="all, delete-orphan"),
                         uselist=False)
 
 

--- a/tests/factories/host.py
+++ b/tests/factories/host.py
@@ -1,0 +1,47 @@
+import factory
+from faker.providers import BaseProvider
+from ipaddr import IPv4Network, IPv4Address
+
+from pycroft.model.host import Host, Interface, IP
+from tests import UserFactory
+from tests.factories.base import BaseFactory
+from tests.factories.facilities import RoomFactory
+from tests.factories.net import SubnetFactory
+
+
+class UnicastMacProvider(BaseProvider):
+    def unicast_mac_address(self):
+        mac = [self.generator.random.randint(0x00, 0xff) for i in range(0, 6)]
+        mac[0] = mac[0] & 0xfe
+        return ':'.join('%02x' % x for x in mac)
+
+
+factory.Faker.add_provider(UnicastMacProvider)
+
+
+class IPFactory(BaseFactory):
+    class Meta:
+        model = IP
+        exclude = ('str_address',)
+
+    str_address = factory.Faker('ipv4', network=False)
+    address = factory.LazyAttribute(lambda o: IPv4Address(o.str_address))
+    # interface = factory.SubFactory(InterfaceFactory)
+    subnet = factory.SubFactory(SubnetFactory, address=IPv4Network('0.0.0.0/0'))
+
+
+class InterfaceFactory(BaseFactory):
+    class Meta:
+        model = Interface
+    mac = factory.Faker('unicast_mac_address')
+    # host = factory.SubFactory('HostFactory')
+    ip = factory.RelatedFactory(IPFactory, 'interface')
+
+
+class HostFactory(BaseFactory):
+    class Meta:
+        model = Host
+
+    owner = factory.SubFactory(UserFactory)
+    room = factory.SubFactory(RoomFactory)
+    interface = factory.RelatedFactory(InterfaceFactory, 'host')

--- a/tests/factories/net.py
+++ b/tests/factories/net.py
@@ -1,0 +1,23 @@
+import factory
+from ipaddr import IPv4Network
+
+from pycroft.model.net import VLAN, Subnet
+from tests.factories.base import BaseFactory
+
+
+class VLANFactory(BaseFactory):
+    class Meta:
+        model = VLAN
+
+    name = factory.Sequence(lambda n: "vlan{}".format(n+1))
+    vid = factory.Sequence(lambda n: n+1)
+
+
+class SubnetFactory(BaseFactory):
+    class Meta:
+        model = Subnet
+        exclude = ('str_address',)
+
+    str_address = factory.Faker('ipv4', network=True)
+    address = factory.LazyAttribute(lambda o: IPv4Network(o.str_address))
+    vlan = factory.SubFactory(VLANFactory)

--- a/tests/factories/traffic.py
+++ b/tests/factories/traffic.py
@@ -5,6 +5,8 @@
 from datetime import timedelta
 import factory
 
+from pycroft.model.traffic import PmacctTrafficEgress, \
+    PmacctTrafficIngress
 from pycroft.model.user import TrafficGroup
 
 from .base import BaseFactory
@@ -20,3 +22,26 @@ class TrafficGroupFactory(BaseFactory):
     credit_amount = 3*2**30
     credit_interval = timedelta(days=1)
     initial_credit_amount = 21*2**30
+
+
+class PMAcctTrafficFactoryBase(BaseFactory):
+    class Meta:
+        abstract = True
+
+    packets = factory.Faker('pyint')
+    bytes = factory.Faker('pyint')
+    stamp_inserted = factory.Faker('date_time_this_year')
+
+
+class PMAcctTrafficEgressFactory(PMAcctTrafficFactoryBase):
+    class Meta:
+        model = PmacctTrafficEgress
+
+    ip_src = None
+
+
+class PMAcctTrafficIngressFactory(PMAcctTrafficFactoryBase):
+    class Meta:
+        model = PmacctTrafficIngress
+
+    ip_dst = None

--- a/tests/factories/user.py
+++ b/tests/factories/user.py
@@ -2,7 +2,7 @@
 # Copyright (c) 2016 The Pycroft Authors. See the AUTHORS file.
 # This file is part of the Pycroft project and licensed under the terms of
 # the Apache License, Version 2.0. See the LICENSE file for details.
-from factory import SubFactory
+import factory
 from factory.faker import Faker
 
 from pycroft.model.user import User
@@ -19,8 +19,9 @@ class UserFactory(BaseFactory):
     registered_at = Faker('date_time')
     password = Faker('password')
     email = Faker('email')
-    account = SubFactory(AccountFactory, type="USER_ASSET")
-    room = SubFactory(RoomFactory)
-    # TODO: create subclasses for `dummy` and `privileged` user
-    # Q: How can we add memberships on the factory level?
-    # A: By using `RelatedFactory, although that can only do one`
+    account = factory.SubFactory(AccountFactory, type="USER_ASSET")
+    room = factory.SubFactory(RoomFactory)
+
+
+class UserWithHostFactory(UserFactory):
+    host = factory.RelatedFactory('tests.factories.host.HostFactory', 'owner')

--- a/tests/fixtures/dummy/traffic.py
+++ b/tests/fixtures/dummy/traffic.py
@@ -12,7 +12,7 @@ class TrafficVolumeData(DataSet):
     class dummy_volume:
         ip = IPData.dummy_user_ipv4
         user = UserData.dummy
-        type = "IN"
+        type = "Ingress"
         amount = int(7.6 * 2**20)
         packets = int(7600)
         timestamp = datetime.utcnow()
@@ -20,7 +20,7 @@ class TrafficVolumeData(DataSet):
     class dummy_volume_before_balance:
         ip = IPData.dummy_user_ipv4
         user = UserData.dummy
-        type = "IN"
+        type = "Ingress"
         amount = int(3.72 * 2**30)
         packets = int(3720)
         timestamp = datetime.utcnow() - timedelta(hours=2)
@@ -28,7 +28,7 @@ class TrafficVolumeData(DataSet):
     class dummy_volume_ipv6:
         ip = IPData.dummy_user_ipv6
         user = UserData.dummy
-        type = "OUT"
+        type = "Egress"
         amount = int(56.1 * 2**20)
         packets = int(5610)
         timestamp = datetime.utcnow() - timedelta(minutes=25)

--- a/tests/fixtures/dummy/traffic.py
+++ b/tests/fixtures/dummy/traffic.py
@@ -10,18 +10,21 @@ from tests.fixtures.dummy.user import UserData
 
 class TrafficVolumeData(DataSet):
     class dummy_volume:
+        user = UserData.dummy
         amount = int(7.6 * 2**20)
         timestamp = datetime.utcnow()
         type = "IN"
         ip = IPData.dummy_user_ipv4
 
     class dummy_volume_before_balance:
+        user = UserData.dummy
         amount = int(3.72 * 2**30)
         timestamp = datetime.utcnow() - timedelta(hours=2)
         type = "IN"
         ip = IPData.dummy_user_ipv4
 
     class dummy_volume_ipv6:
+        user = UserData.dummy
         amount = int(56.1 * 2**20)
         timestamp = datetime.utcnow() - timedelta(minutes=25)
         type = "OUT"
@@ -55,4 +58,3 @@ class TrafficBalanceData(DataSet):
         user = UserData.anotheruser
         timestamp = datetime.utcnow() + timedelta(days=1)
         amount = int(6.12 * 2**30)
-

--- a/tests/fixtures/dummy/traffic.py
+++ b/tests/fixtures/dummy/traffic.py
@@ -10,25 +10,28 @@ from tests.fixtures.dummy.user import UserData
 
 class TrafficVolumeData(DataSet):
     class dummy_volume:
-        user = UserData.dummy
-        amount = int(7.6 * 2**20)
-        timestamp = datetime.utcnow()
-        type = "IN"
         ip = IPData.dummy_user_ipv4
+        user = UserData.dummy
+        type = "IN"
+        amount = int(7.6 * 2**20)
+        packets = int(7600)
+        timestamp = datetime.utcnow()
 
     class dummy_volume_before_balance:
-        user = UserData.dummy
-        amount = int(3.72 * 2**30)
-        timestamp = datetime.utcnow() - timedelta(hours=2)
-        type = "IN"
         ip = IPData.dummy_user_ipv4
+        user = UserData.dummy
+        type = "IN"
+        amount = int(3.72 * 2**30)
+        packets = int(3720)
+        timestamp = datetime.utcnow() - timedelta(hours=2)
 
     class dummy_volume_ipv6:
-        user = UserData.dummy
-        amount = int(56.1 * 2**20)
-        timestamp = datetime.utcnow() - timedelta(minutes=25)
-        type = "OUT"
         ip = IPData.dummy_user_ipv6
+        user = UserData.dummy
+        type = "OUT"
+        amount = int(56.1 * 2**20)
+        packets = int(5610)
+        timestamp = datetime.utcnow() - timedelta(minutes=25)
 
 
 class TrafficCreditData(DataSet):

--- a/tests/model/test_ddl.py
+++ b/tests/model/test_ddl.py
@@ -210,5 +210,3 @@ class ViewTest(DDLTest):
         stmt = DropView(view, cascade=True)
         self.assertEqual('DROP VIEW view CASCADE',
                          literal_compile(stmt))
-
-

--- a/tests/model/test_ddl.py
+++ b/tests/model/test_ddl.py
@@ -160,10 +160,10 @@ class ViewTest(DDLTest):
 
     def test_create_view_with_view_options(self):
         table = create_table("table")
-        view = View("view", select([table.c.id]), view_options={
-            'check_option': 'cascaded',
-            'security_barrier': 't',
-        })
+        view = View("view", select([table.c.id]), view_options=[
+            ('check_option', 'cascaded'),
+            ('security_barrier', 't'),
+        ])
         stmt = CreateView(view)
         self.assertEqual('CREATE VIEW view '
                          'WITH (check_option = cascaded, security_barrier = t) '

--- a/tests/model/test_ddl.py
+++ b/tests/model/test_ddl.py
@@ -1,0 +1,205 @@
+import unittest
+
+from sqlalchemy import PrimaryKeyConstraint, Table, Column, Integer, MetaData, \
+    select, text
+from sqlalchemy.dialects import postgresql
+
+from pycroft.model.ddl import DropConstraint, CreateFunction, DropFunction, \
+    Function, View, CreateView, DropView, Rule, CreateRule, ConstraintTrigger, \
+    CreateConstraintTrigger
+
+
+def literal_compile(stmt):
+    return str(stmt.compile(compile_kwargs={"literal_binds": True},
+                            dialect=postgresql.dialect()))
+
+
+def create_table(name):
+    return Table(name, MetaData(), Column("id", Integer))
+
+
+class DDLTest(unittest.TestCase):
+    pass
+
+
+class ConstraintTest(DDLTest):
+    def test_drop_constraint_if_exists(self):
+        table = create_table("test")
+        stmt = DropConstraint(
+            PrimaryKeyConstraint(table.c.id, name="pk_constraint"),
+            if_exists=True)
+        self.assertEqual(
+            "ALTER TABLE test DROP CONSTRAINT IF EXISTS pk_constraint",
+            literal_compile(stmt))
+
+    def test_drop_constraint_identifier_quotation(self):
+        table = create_table("TABLE")
+        stmt = DropConstraint(PrimaryKeyConstraint(table.c.id, name='PRIMARY'))
+        self.assertEqual('ALTER TABLE "TABLE" DROP CONSTRAINT "PRIMARY"',
+                         literal_compile(stmt))
+
+
+class FunctionTest(DDLTest):
+    def test_create_function(self):
+        func = Function("do_foo()", "INTEGER", "BEGIN; RETURN NULL; END;")
+        stmt = CreateFunction(func)
+        self.assertEqual('CREATE FUNCTION "do_foo()" '
+                         'RETURNS INTEGER VOLATILE $$\n'
+                         'BEGIN; RETURN NULL; END;\n'
+                         '$$',
+                         literal_compile(stmt))
+
+
+class ConstraintTriggerTest(DDLTest):
+    def test_create_constraint_trigger(self):
+        table = create_table("test")
+        trigger = ConstraintTrigger("test_trigger", table, "INSERT", "do_foo()")
+        stmt = CreateConstraintTrigger(trigger)
+        self.assertEqual('CREATE FUNCTION "do_foo()" '
+                         'RETURNS INTEGER VOLATILE $$\n'
+                         'BEGIN; RETURN NULL; END;\n'
+                         '$$',
+                         literal_compile(stmt))
+
+
+class RuleTest(DDLTest):
+    def test_create_rule(self):
+        table = create_table("test")
+        rule = Rule("test_select", table, "SELECT", "NOTHING")
+        stmt = CreateRule(rule)
+        self.assertEqual('CREATE RULE test_select AS ON SELECT TO test '
+                         'DO NOTHING',
+                         literal_compile(stmt))
+
+    def test_create_or_replace_rule(self):
+        table = create_table("test")
+        rule = Rule("test_select", table, "SELECT", "NOTHING", do_instead=True)
+        stmt = CreateRule(rule, or_replace=True)
+        self.assertEqual('CREATE OR REPLACE RULE test_select AS ON SELECT '
+                         'TO test DO INSTEAD NOTHING',
+                         literal_compile(stmt))
+
+    def test_create_instead_rule(self):
+        table = create_table("test")
+        rule = Rule("test_select", table, "SELECT", "NOTHING", do_instead=True)
+        stmt = CreateRule(rule)
+        self.assertEqual('CREATE RULE test_select AS ON SELECT TO test '
+                         'DO INSTEAD NOTHING',
+                         literal_compile(stmt))
+
+    def test_create_insert_rule(self):
+        table1 = create_table("test")
+        table2 = create_table("other")
+        rule = Rule("test_insert", table1, "INSERT",
+                    table2.insert().values(id=text("NEW.id")))
+        stmt = CreateRule(rule)
+        self.assertEqual('CREATE RULE test_insert AS ON INSERT TO test '
+                         'DO INSERT INTO other (id) VALUES (NEW.id)',
+                         literal_compile(stmt))
+
+    def test_create_multiple_command_rule(self):
+        table1 = create_table("test")
+        table2 = create_table("other")
+        table3 = create_table("yet_other")
+        rule = Rule("test_insert", table1, "INSERT", [
+            table2.insert().values(id=text("NEW.id")),
+            table3.insert().values(id=text("NEW.id")),
+        ])
+        stmt = CreateRule(rule)
+        self.assertEqual('CREATE RULE test_insert AS ON INSERT TO test '
+                         'DO ('
+                         'INSERT INTO other (id) VALUES (NEW.id); '
+                         'INSERT INTO yet_other (id) VALUES (NEW.id)'
+                         ')',
+                         literal_compile(stmt))
+
+    def test_create_update_rule(self):
+        table1 = create_table("test")
+        table2 = create_table("other")
+        rule = Rule("test_update", table1, "UPDATE",
+                    table2.update().values(id=text("NEW.id")))
+        stmt = CreateRule(rule)
+        self.assertEqual('CREATE RULE test_update AS ON UPDATE TO test '
+                         'DO UPDATE other SET id=NEW.id',
+                         literal_compile(stmt))
+
+    def test_create_delete_rule(self):
+        table1 = create_table("test")
+        table2 = create_table("other")
+        rule = Rule("test_delete", table1, "DELETE", table2.delete())
+        stmt = CreateRule(rule)
+        self.assertEqual('CREATE RULE test_delete AS ON DELETE TO test '
+                         'DO DELETE FROM other',
+                         literal_compile(stmt))
+
+
+class ViewTest(DDLTest):
+    def test_plain_create_view(self):
+        table = create_table("table")
+        view = View("view", select([table.c.id]))
+        stmt = CreateView(view)
+        self.assertEqual('CREATE VIEW view AS SELECT "table".id \n'
+                         'FROM "table"',
+                         literal_compile(stmt))
+
+    def test_create_or_replace_view(self):
+        table = create_table("table")
+        view = View("view", select([table.c.id]))
+        stmt = CreateView(view, or_replace=True)
+        self.assertEqual('CREATE OR REPLACE VIEW view AS SELECT "table".id \n'
+                         'FROM "table"',
+                         literal_compile(stmt))
+
+    def test_create_temporary_view(self):
+        table = create_table("table")
+        view = View("view", select([table.c.id]), temporary=True)
+        stmt = CreateView(view)
+        self.assertEqual('CREATE TEMPORARY VIEW view AS SELECT "table".id \n'
+                         'FROM "table"',
+                         literal_compile(stmt))
+
+    def test_create_view_with_view_options(self):
+        table = create_table("table")
+        view = View("view", select([table.c.id]), view_options={
+            'check_option': 'cascaded',
+            'security_barrier': 't',
+        })
+        stmt = CreateView(view)
+        self.assertEqual('CREATE VIEW view '
+                         'WITH (check_option = cascaded, security_barrier = t) '
+                         'AS SELECT "table".id \n'
+                         'FROM "table"',
+                         literal_compile(stmt))
+
+    def test_create_view_with_check_option(self):
+        table = create_table("table")
+        view = View("view", select([table.c.id]), check_option='cascaded')
+        stmt = CreateView(view)
+        self.assertEqual('CREATE VIEW view '
+                         'AS SELECT "table".id \n'
+                         'FROM "table" '
+                         'WITH CASCADED CHECK OPTION',
+                         literal_compile(stmt))
+
+    def test_drop_view(self):
+        table = create_table("table")
+        view = View("view", select([table.c.id]))
+        stmt = DropView(view)
+        self.assertEqual('DROP VIEW view',
+                         literal_compile(stmt))
+
+    def test_drop_view_if_exists(self):
+        table = create_table("table")
+        view = View("view", select([table.c.id]))
+        stmt = DropView(view, if_exists=True)
+        self.assertEqual('DROP VIEW IF EXISTS view',
+                         literal_compile(stmt))
+
+    def test_drop_view_cascade(self):
+        table = create_table("table")
+        view = View("view", select([table.c.id]))
+        stmt = DropView(view, cascade=True)
+        self.assertEqual('DROP VIEW view CASCADE',
+                         literal_compile(stmt))
+
+

--- a/tests/model/test_ddl.py
+++ b/tests/model/test_ddl.py
@@ -43,8 +43,17 @@ class FunctionTest(DDLTest):
     def test_create_function(self):
         func = Function("do_foo", [], "INTEGER", "BEGIN; RETURN NULL; END;")
         stmt = CreateFunction(func)
-        self.assertEqual('CREATE FUNCTION "do_foo()" '
-                         'RETURNS INTEGER VOLATILE $$\n'
+        self.assertEqual('CREATE FUNCTION do_foo() '
+                         'RETURNS INTEGER VOLATILE LANGUAGE sql AS $$\n'
+                         'BEGIN; RETURN NULL; END;\n'
+                         '$$',
+                         literal_compile(stmt))
+
+    def test_create_function_with_quoting(self):
+        func = Function("do foo", [], "INTEGER", "BEGIN; RETURN NULL; END;")
+        stmt = CreateFunction(func)
+        self.assertEqual('CREATE FUNCTION "do foo"() '
+                         'RETURNS INTEGER VOLATILE LANGUAGE sql AS $$\n'
                          'BEGIN; RETURN NULL; END;\n'
                          '$$',
                          literal_compile(stmt))
@@ -55,10 +64,10 @@ class ConstraintTriggerTest(DDLTest):
         table = create_table("test")
         trigger = ConstraintTrigger("test_trigger", table, "INSERT", "do_foo()")
         stmt = CreateConstraintTrigger(trigger)
-        self.assertEqual('CREATE FUNCTION "do_foo()" '
-                         'RETURNS INTEGER VOLATILE $$\n'
-                         'BEGIN; RETURN NULL; END;\n'
-                         '$$',
+        self.assertEqual('CREATE CONSTRAINT TRIGGER test_trigger '
+                         'AFTER I OR N OR S OR E OR R OR T '
+                         'ON test FOR EACH ROW EXECUTE PROCEDURE '
+                         'do_foo()',
                          literal_compile(stmt))
 
 

--- a/tests/model/test_ddl.py
+++ b/tests/model/test_ddl.py
@@ -41,7 +41,7 @@ class ConstraintTest(DDLTest):
 
 class FunctionTest(DDLTest):
     def test_create_function(self):
-        func = Function("do_foo()", "INTEGER", "BEGIN; RETURN NULL; END;")
+        func = Function("do_foo", [], "INTEGER", "BEGIN; RETURN NULL; END;")
         stmt = CreateFunction(func)
         self.assertEqual('CREATE FUNCTION "do_foo()" '
                          'RETURNS INTEGER VOLATILE $$\n'

--- a/tests/model/test_traffic.py
+++ b/tests/model/test_traffic.py
@@ -1,0 +1,41 @@
+from pycroft.model.traffic import PmacctTrafficEgress, PmacctTrafficIngress, TrafficVolume
+from tests import FactoryDataTestBase
+from tests.factories.traffic import PMAcctTrafficEgressFactory, PMAcctTrafficIngressFactory
+from tests.factories.user import UserWithHostFactory
+
+
+class PMAcctPseudoTableTest(FactoryDataTestBase):
+    ip = '141.30.228.39'
+    bad_ip = '141.30.228.1'
+    def create_factories(self):
+        self.user = UserWithHostFactory(host__interface__ip__str_address=self.ip)
+
+    def test_egress_insert(self):
+        egress_traffic = PMAcctTrafficEgressFactory.create(ip_src=self.ip)
+        self.assertEqual(PmacctTrafficEgress.q.count(), 0)
+        self.assertEqual(TrafficVolume.q.count(), 1)
+        volume = TrafficVolume.q.one()
+        self.assertEqual(volume.type, 'Egress')
+        self.assertEqual(volume.amount, egress_traffic.bytes)
+        self.assertEqual(volume.packets, egress_traffic.packets)
+        self.assertEqual(volume.user, self.user)
+
+    def test_egress_insert_nonexistent_ip(self):
+        PMAcctTrafficEgressFactory.create(ip_src=self.bad_ip)
+        self.assertEqual(PmacctTrafficEgress.q.count(), 0)
+        self.assertEqual(TrafficVolume.q.count(), 0)
+
+    def test_ingress_insert(self):
+        ingress_traffic = PMAcctTrafficIngressFactory.create(ip_dst=self.ip)
+        self.assertEqual(PmacctTrafficIngress.q.count(), 0)
+        self.assertEqual(TrafficVolume.q.count(), 1)
+        volume = TrafficVolume.q.one()
+        self.assertEqual(volume.type, 'Ingress')
+        self.assertEqual(volume.amount, ingress_traffic.bytes)
+        self.assertEqual(volume.packets, ingress_traffic.packets)
+        self.assertEqual(volume.user, self.user)
+
+    def test_ingress_insert_nonexistent_ip(self):
+        PMAcctTrafficIngressFactory.create(ip_dst=self.bad_ip)
+        self.assertEqual(PmacctTrafficEgress.q.count(), 0)
+        self.assertEqual(TrafficVolume.q.count(), 0)

--- a/web/blueprints/user/__init__.py
+++ b/web/blueprints/user/__init__.py
@@ -337,12 +337,10 @@ def json_trafficdata(user_id, days=7):
     traffic_timespan = (session.utcnow() - timedelta(days=days)).date()
     # get all traffic volumes for the user in the timespan
 
-    traffic_volumes = TrafficVolume.q.join(IP).join(Interface).join(Host
-        ).filter(
-            and_(TrafficVolume.timestamp > traffic_timespan,
-                 Host.owner_id == user_id)
-        ).order_by(
-            TrafficVolume.timestamp)
+    traffic_volumes = TrafficVolume.q.filter(
+        TrafficVolume.user_id == user_id,
+        TrafficVolume.timestamp > traffic_timespan).order_by(
+        TrafficVolume.timestamp)
 
     traffic_volumes = json_agg(traffic_volumes).one()[0]
 

--- a/web/templates/finance/accounts_show.html
+++ b/web/templates/finance/accounts_show.html
@@ -71,8 +71,6 @@ var margin = {top: 20, right: 20, bottom: 30, left: 50},
     width = _width - margin.left - margin.right,
     height = 150 - margin.top - margin.bottom;
 
-var parseDate = de.timeFormat("%Y-%m-%d").parse;
-
 var x = d3.time.scale()
     .range([0, width]);
 
@@ -119,7 +117,7 @@ d3.json("{{ balance_json_url }}", function(error, resp) {
 
   data = resp.items;
   data.forEach(function(d) {
-    d.valid_on = parseDate(d.valid_on);
+    d.valid_on = d3.isoParse(d.valid_on);
     d.balance = +d.balance/100.; //converts string to number
   });
 

--- a/web/templates/finance/accounts_show.html
+++ b/web/templates/finance/accounts_show.html
@@ -117,7 +117,7 @@ d3.json("{{ balance_json_url }}", function(error, resp) {
 
   data = resp.items;
   data.forEach(function(d) {
-    d.valid_on = d3.isoParse(d.valid_on);
+    d.valid_on = d3.time.format.iso.parse(d.valid_on);
     d.balance = +d.balance/100.; //converts string to number
   });
 

--- a/web/templates/user/_user_show_traffic.html
+++ b/web/templates/user/_user_show_traffic.html
@@ -84,7 +84,7 @@
       .range([height, 0]);
 
   var color = d3.scale.ordinal()
-  .domain(["IN", "OUT"])
+  .domain(["Ingress", "Egress"])
   .range(["lightsteelblue", "#deb0c4"]);
 
   var xAxis = d3.svg.axis()

--- a/web/templates/user/_user_show_traffic.html
+++ b/web/templates/user/_user_show_traffic.html
@@ -74,8 +74,6 @@
       width = _width - margin.left - margin.right,
       height = 200 - margin.top - margin.bottom;
 
-  var parseTimestamp = de.timeFormat("%Y-%m-%dT%H:%M:%S").parse;
-
   var x = d3.time.scale()
       .range([0, width]);
 
@@ -160,13 +158,7 @@
         if (data === null) return;
 
         data.forEach(function(d) {
-            var ts = parseTimestamp(d.timestamp);
-            if (ts === null) {
-                ts = parseTimestamp(d.timestamp.replace(/.\d+$/, "")); //chop off µs
-                if (ts === null) throw "Could not parse timestamp "+d.timestamp;
-            }
-
-            d.timestamp = ts
+            d.timestamp = d3.isoParse(d.timestamp);
         });
 
         // Determine the first and last dates in the data set

--- a/web/templates/user/_user_show_traffic.html
+++ b/web/templates/user/_user_show_traffic.html
@@ -158,7 +158,7 @@
         if (data === null) return;
 
         data.forEach(function(d) {
-            d.timestamp = d3.isoParse(d.timestamp);
+            d.timestamp = d3.time.format.iso.parse(d.timestamp);
         });
 
         // Determine the first and last dates in the data set

--- a/web/templates/user/_user_show_traffic.html
+++ b/web/templates/user/_user_show_traffic.html
@@ -162,7 +162,7 @@
         data.forEach(function(d) {
             var ts = parseTimestamp(d.timestamp);
             if (ts === null) {
-                ts = parseTimestamp(d.timestamp.slice(0, -7)); //chop off µs
+                ts = parseTimestamp(d.timestamp.replace(/.\d+$/, "")); //chop off µs
                 if (ts === null) throw "Could not parse timestamp "+d.timestamp;
             }
 


### PR DESCRIPTION
Fixes #111, about to fix #122 

Left todo:

- [x] Compiler bug:  `DropFunction` misses `cascade` attribute
- [x] Compiler bug: `DropFunction` quotes the whole function identifier including parameters, not just the name: `DROP FUNCTION IF EXISTS "account_is_type(integer, account_type)"` is issued, `DROP FUNCTION IF EXISTS "account_is_type"(integer, account_type)` would be correct.
- [x] Include creation query for pmacct ghost-table rule
- [x] Test pmacct table rule