### PR TITLE
Hades

### DIFF
--- a/helpers/interactive.py
+++ b/helpers/interactive.py
@@ -27,8 +27,10 @@ from pycroft import config
 
 connection_string = os.environ['PYCROFT_DB_URI']
 
+engine = create_engine(connection_string, echo=True)
+
+
 def setup():
-    engine = create_engine(connection_string, echo=True)
     # TODO: don't set a scoped session, just a regular one
     set_scoped_session(scoped_session(sessionmaker(bind=engine),
                                       scopefunc=lambda: _request_ctx_stack.top))

--- a/legacy/import_conf.py
+++ b/legacy/import_conf.py
@@ -49,6 +49,8 @@ group_props = {
 
     "suspended": ("Gesperrt", {"network_access": False}),
 
+    "finance": ("Zahlungsrückstand", {"network_access": False, "default_in_payment": True}),
+    "traffic": ("Trafficüberschreitung", {"network_access": False, "traffic_limit_exceeded": True}),
     "violator": ("Verstoß gegen Netzordnung", {"network_access": False,
                                               "violation": True}),
 

--- a/legacy/import_conf.py
+++ b/legacy/import_conf.py
@@ -87,18 +87,19 @@ group_props = {
 
 # Memberships being added due to the current status
 status_groups_map = {
+    # `usertraffic` is a traffic group, so not given in `import_conf`
     1: ("member", "usertraffic"),  # bezahlt, ok
-    2: ("member", "usertraffic"),  # angemeldet, aber nicht bezahlt
+    2: ("member", "finance", "usertraffic"),  # angemeldet, aber nicht bezahlt
     3: ("away",),    # nicht bezahlt, hat nur Mail
-    4: ("member", "usertraffic"),  # angemeldet, nicht bezahlt, 2. Warnung
+    4: ("member", "finance", "usertraffic"),  # angemeldet, nicht bezahlt, 2. Warnung
     5: ("member", "suspended", "usertraffic"),  # angemeldet, nicht bezahlt, gesperrt
     6: ("away",),  # angemeldet, gesperrt (ruhend)
-    7: ("member", "violator"),  # angemeldet, gesperrt (Verstoss gegen Netzordnung)
+    7: ("member", "violator", "usertraffic"),  # angemeldet, gesperrt (Verstoss gegen Netzordnung)
     8: (),  # ausgezogen, gesperrt
     9: (),  # Ex-Aktiver
     10: ("away",), # E-Mail, ehemals IP
     11: (),  # uebrig in Wu die in Renovierung
-    12: ("member", "usertraffic")  # gesperrt wegen Trafficueberschreitung
+    12: ("member", "traffic", "usertraffic")  # gesperrt wegen Trafficueberschreitung
 }
 
 

--- a/legacy/import_legacy.py
+++ b/legacy/import_legacy.py
@@ -9,6 +9,7 @@ import sys
 from collections import Counter
 import logging as std_logging
 
+from pycroft.model.hades import radius_property
 from scripts.schema import AlembicHelper
 
 log = std_logging.getLogger('import')
@@ -199,6 +200,12 @@ def import_legacy(args):
     iter_bad_rooms = (r for r in room_query.all() if not r[0])
     for bad_room in iter_bad_rooms:
         log.warning("Room %s isn't connected to any subnets", bad_room)
+
+    log.info('Inserting radius properties...')
+    session.session.execute(radius_property.insert([('violation',),
+                                                    ('payment_in_default',),
+                                                    ('traffic_limit_exceeded',)]))
+    session.session.commit()
 
     log.info("Fixing sequences...")
 

--- a/pycroft/model/_all.py
+++ b/pycroft/model/_all.py
@@ -22,4 +22,5 @@ from .port import *
 from .net import *
 from .user import *
 from .property import *
+from .hades import *
 from .webstorage import *

--- a/pycroft/model/hades.py
+++ b/pycroft/model/hades.py
@@ -11,7 +11,6 @@ hades_view_ddl = DDLManager()
 
 radusergroup = View(
     name='radusergroup',
-    metadata=ModelBase.metadata,
     query=union_all(
         # Priority 0: valid case (interface's mac w/ vlan at correct ports)
         Query([]).add_columns(
@@ -36,7 +35,6 @@ radusergroup = View(
 
 radcheck = View(
     name='radcheck',
-    metadata=ModelBase.metadata,
     query=(
         # This adds all existing interfaces.
         Query([]).add_columns(
@@ -59,7 +57,6 @@ radcheck = View(
 
 radgroupcheck = View(
     name='radgroupcheck',
-    metadata=ModelBase.metadata,
     query=Query([
         literal(1).label('id'),
         literal("unknown").label('groupname'),
@@ -94,7 +91,6 @@ radgroupreply_base = Table(
 
 radgroupreply = View(
     name='radgroupreply',
-    metadata=ModelBase.metadata,
     query=union_all(
         Query([
             radgroupreply_base.c.id.label('id'),

--- a/pycroft/model/hades.py
+++ b/pycroft/model/hades.py
@@ -6,30 +6,90 @@ from pycroft.model.ddl import DDLManager, View
 from pycroft.model.facilities import Room
 from pycroft.model.host import Interface, Switch, SwitchPort, Host
 from pycroft.model.net import VLAN, Subnet
+from pycroft.model.user import User
+from pycroft.model.property import current_property
 
 hades_view_ddl = DDLManager()
+
+network_access_subq = (
+    # Select `user_id, 1` for all people with network_access
+    Query([current_property.table.c.user_id.label('user_id'),
+           literal(1).label('network_access')])
+    .filter(current_property.table.c.property_name == 'network_access')
+    .subquery('users_with_network_access')
+)
+
+radgroup_property_mappings = Table(
+    'radgroup_property_mappings',
+    ModelBase.metadata,
+    Column('property', String, primary_key=True),
+    Column('radgroup', String(128), nullable=False),
+)
 
 radusergroup = View(
     name='radusergroup',
     query=union_all(
-        # Priority 0: valid case (interface's mac w/ vlan at correct ports)
-        Query([]).add_columns(
+        # Priority 20: valid case (interface's mac w/ vlan at correct ports)
+        # <mac> @ <switch>/<port> → <vlan>_[un]tagged (Prio 20)
+        Query([
             Interface.mac.label('username'),
             # `host()` does not print the `/32` like `text` would
             func.host(Switch.management_ip).label('nasipaddress'),
             SwitchPort.name.label('nasportid'),
             # TODO: add `_tagged` instead if interface needs that
             (VLAN.name + '_untagged').label('groupname'),
+            literal(20).label('priority'),
+        ]).select_from(User)
+        .join(Host)
+        .join(Interface)
+        .join(Host.room)
+        .join(Room.connected_patch_ports)
+        .join(SwitchPort)
+        .join(Switch)
+        .join(Interface.ips)
+        .join(Subnet)
+        .join(VLAN)
+        .join(current_property.table, current_property.table.c.user_id == User.id)
+        .filter(current_property.table.c.property_name == 'network_access')
+        .statement,
+
+        # Priority 10: Blocking reason exists
+        # <mac> @ <switch>/<port> → finance (Prio 10)
+        Query([
+            Interface.mac.label('username'),
+            func.host(Switch.management_ip).label('nasipaddress'),
+            SwitchPort.name.label('nasportid'),
+            radgroup_property_mappings.c.radgroup.label('groupname'),
+            literal(10).label('priority'),
+        ]).select_from(User)
+        .join(Host)
+        .join(Host.interfaces)
+        .join(Host.room)
+        .join(Room.connected_patch_ports)
+        .join(SwitchPort)
+        .join(Switch)
+        .join(current_property.table, current_property.table.c.user_id == User.id)
+        .join(radgroup_property_mappings,
+              radgroup_property_mappings.c.property == current_property.table.c.property_name)
+        .statement,
+
+        # Priority 0: No blocking reason exists → assume no member (yet/anymore)
+        Query([
+            Interface.mac.label('username'),
+            func.host(Switch.management_ip).label('nasipaddress'),
+            SwitchPort.name.label('nasportid'),
+            literal('no_member').label('groupname'),
             literal(0).label('priority'),
-        ).select_from(Interface)
-         .join(Host)
-         .join(Room)
-         .join(Room.connected_patch_ports)
-         .join(SwitchPort)
-         .join(Switch)
-         .join(Interface.ips)
-         .join(Subnet)
-         .join(VLAN),
+        ]).select_from(User)
+        .outerjoin(network_access_subq, User.id == network_access_subq.c.user_id)
+        .filter(network_access_subq.c.network_access == None)
+        .join(User.hosts)
+        .join(Host.interfaces)
+        .join(Host.room)
+        .join(Room.connected_patch_ports)
+        .join(SwitchPort)
+        .join(Switch)
+        .statement,
     ),
 )
 

--- a/pycroft/model/hades.py
+++ b/pycroft/model/hades.py
@@ -1,0 +1,55 @@
+from sqlalchemy import literal, Column, String, BigInteger, func
+from sqlalchemy.orm import Query
+
+from pycroft.model.base import ModelBase
+from pycroft.model.ddl import DDLManager, View
+from pycroft.model.facilities import Room
+from pycroft.model.host import Interface, Switch, SwitchPort, Host
+
+hades_view_ddl = DDLManager()
+
+radusergroup = View(
+    name='radusergroup',
+    metadata=ModelBase.metadata,
+    query=(
+        # This adds all existing interfaces.
+        Query([]).add_columns(
+            Interface.mac.label('username'),
+            # `host()` does not print the `/32` like `text` would
+            func.host(Switch.management_ip).label('nasipaddress'),
+            SwitchPort.name.label('nasportid'),
+            # testgroup and priority have dummy values atm
+            literal("testgroup").label('groupname'),
+            literal(0).label('priority'),
+        ).select_from(Interface)
+         .join(Host)
+         .join(Room)
+         .join(Room.connected_patch_ports)
+         .join(SwitchPort)
+         .join(Switch)
+         .statement
+    ),
+)
+
+radcheck = View(
+    name='radcheck',
+    metadata=ModelBase.metadata,
+    query=(
+        # This adds all existing interfaces.
+        Query([]).add_columns(
+            Interface.id.label('id'),
+            func.text(Interface.mac).label('username'),
+            func.host(Switch.management_ip).label('nasipaddress'),
+            SwitchPort.name.label('nasportid'),
+            literal("Cleartext-Password").label('attribute'),
+            literal(":=").label('op'),
+            func.text(Interface.mac).label('value'),
+        ).select_from(Interface)
+         .join(Host)
+         .join(Room)
+         .join(Room.connected_patch_ports)
+         .join(SwitchPort)
+         .join(Switch)
+         .statement
+    ),
+)

--- a/pycroft/model/hades.py
+++ b/pycroft/model/hades.py
@@ -187,6 +187,12 @@ radgroupreply = View(
             literal('+=').label('Op'),
             (literal('1') + VLAN.name).label('Value'),
         ]),
+        Query([
+            radius_property.c.property.label('GroupName'),
+            literal("Egress-VLAN-Name").label('Attribute'),
+            literal(":=").label('Op'),
+            literal("2hades-unauth").label('Value'),
+        ])
     ),
 )
 hades_view_ddl.add_view(radius_property, radgroupreply)

--- a/pycroft/model/hades.py
+++ b/pycroft/model/hades.py
@@ -1,5 +1,5 @@
 from sqlalchemy import literal, Column, String, BigInteger, func, union_all, Table, Integer, \
-    PrimaryKeyConstraint
+    PrimaryKeyConstraint, null
 from sqlalchemy.orm import Query
 
 from pycroft.model.base import ModelBase
@@ -117,9 +117,9 @@ radcheck = View(
             func.text(Interface.mac).label('UserName'),
             func.host(Switch.management_ip).label('NASIPAddress'),
             SwitchPort.name.label('NASPortId'),
-            literal("Cleartext-Password").label('Attribute'),
-            literal(":=").label('Op'),
-            func.text(Interface.mac).label('Value'),
+            literal("User-Name").label('Attribute'),
+            literal("=*").label('Op'),
+            null().label('Value'),
             literal(10).label('Priority'),
         ]).select_from(Interface)
         .join(Host)

--- a/pycroft/model/hades.py
+++ b/pycroft/model/hades.py
@@ -1,4 +1,4 @@
-from sqlalchemy import literal, Column, String, BigInteger, func, union_all, Table
+from sqlalchemy import literal, Column, String, BigInteger, func, union_all, Table, Integer
 from sqlalchemy.orm import Query
 
 from pycroft.model.base import ModelBase
@@ -55,6 +55,19 @@ radcheck = View(
     ),
 )
 
+radreply = Table(
+    'radreply',
+    ModelBase.metadata,
+    Column('id', Integer, primary_key=True),
+    Column('username', String(64), nullable=False),
+    # non-standard columns, not sure if needed
+    # Column('nasipaddress', String(15), nullable=False),
+    # Column('nasportid', String(50), nullable=False),
+    Column('attribute', String(64), nullable=False),
+    Column('op', String(2), nullable=False),
+    Column('value', String(253), nullable=False),
+)
+
 radgroupreply_base = Table(
     'radgroupreply_base',
     ModelBase.metadata,
@@ -105,4 +118,18 @@ radgroupreply = View(
             (VLAN.name + '_tagged').label('value'),
         ]),
     ),
+)
+
+nas = Table(
+    'nas',
+    ModelBase.metadata,
+    Column('id', Integer, primary_key=True),
+    Column('nasname', String(128), nullable=False),
+    Column('shortname', String(32), nullable=False),
+    Column('type', String(30), nullable=False, default='other'),
+    Column('ports', Integer),
+    Column('secret', String(60), nullable=False),
+    Column('server', String(64)),
+    Column('community', String(50)),
+    Column('description', String(200)),
 )

--- a/pycroft/model/hades.py
+++ b/pycroft/model/hades.py
@@ -188,18 +188,6 @@ radgroupreply = View(
             literal('+=').label('Op'),
             (literal('1') + VLAN.name).label('Value'),
         ]),
-        Query([
-            (VLAN.name + '_untagged').label('GroupName'),
-            literal("Reply-Message").label('Attribute'),
-            literal('+=').label('Op'),
-            (VLAN.name + '_untagged').label('Value'),
-        ]),
-        Query([
-            (VLAN.name + '_tagged').label('GroupName'),
-            literal("Reply-Message").label('Attribute'),
-            literal('+=').label('Op'),
-            (VLAN.name + '_tagged').label('Value'),
-        ]),
     ),
 )
 hades_view_ddl.add_view(radgroup_property_mappings, radgroupreply)

--- a/pycroft/model/hades.py
+++ b/pycroft/model/hades.py
@@ -55,6 +55,18 @@ radcheck = View(
     ),
 )
 
+radgroupcheck = View(
+    name='radgroupcheck',
+    metadata=ModelBase.metadata,
+    query=Query([
+        literal(1).label('id'),
+        literal("unknown").label('groupname'),
+        literal("Auth-Type").label('attribute'),
+        literal(":=").label('op'),
+        literal("Accept").label('value'),
+    ]).statement,
+)
+
 radreply = Table(
     'radreply',
     ModelBase.metadata,

--- a/pycroft/model/property.py
+++ b/pycroft/model/property.py
@@ -39,4 +39,13 @@ current_property = View(
 )
 property_view_ddl.add_view(Membership.__table__, current_property)
 
+
+class CurrentProperty(ModelBase):
+    __table__ = current_property.table
+    __mapper_args__ = {
+        'primary_key': (current_property.table.c.user_id,
+                        current_property.table.c.property_name),
+    }
+
+
 property_view_ddl.register()

--- a/pycroft/model/user.py
+++ b/pycroft/model/user.py
@@ -80,6 +80,16 @@ class User(IntegerIdModel, UserMixin):
     def current_credit(self):
         return self._current_traffic_balance.amount
 
+    _current_properties = relationship(
+        'CurrentProperty',
+        primaryjoin='User.id == foreign(CurrentProperty.user_id)',
+        viewonly=True
+    )
+
+    @property
+    def current_properties(self):
+        return [p.property_name for p in self._current_properties]
+
     login_regex = re.compile(r"""
         ^
         # Must begin with a lowercase character

--- a/tests/model/test_hades.py
+++ b/tests/model/test_hades.py
@@ -1,0 +1,66 @@
+from datetime import datetime, timedelta
+
+from pycroft.model import session
+from pycroft.model.hades import radgroup_property_mappings, radcheck
+from tests import FactoryDataTestBase
+from tests.factories import PropertyGroupFactory, MembershipFactory, UserWithHostFactory, \
+    SwitchFactory, PatchPortFactory
+
+
+class HadesViewTest(FactoryDataTestBase):
+    def create_factories(self):
+        self.user = UserWithHostFactory.create()
+        self.network_access_group = PropertyGroupFactory.create(
+            name="Member",
+            granted={'network_access'},
+        )
+        self.blocked_by_finance_group = PropertyGroupFactory.create(
+            name="Blocked (finance)",
+            granted={'blocked_by_finance'},
+            denied={'network_access'},
+        )
+        self.blocked_by_traffic_group = PropertyGroupFactory.create(
+            name="Blocked (traffic)",
+            granted={'blocked_by_traffic'},
+            denied={'network_access'},
+        )
+
+        # the user's room needs to be connected to provide `nasipaddress` and `nasportid`
+        # TODO: remove owner and see if things still work
+        self.switch = SwitchFactory.create(host__owner=self.user)
+        PatchPortFactory.create_batch(2, patched=True, switch_port__switch=self.switch,
+                                      # This needs to be the HOSTS room!
+                                      room=self.user.hosts[0].room)
+
+        # TODO: create this membership in each test, not here
+        MembershipFactory.create(user=self.user, group=self.network_access_group,
+                                 begins_at=datetime.now() + timedelta(-1),
+                                 ends_at=datetime.now() + timedelta(1))
+        MembershipFactory.create(user=self.user, group=self.blocked_by_finance_group,
+                                 begins_at=datetime.now() + timedelta(-1),
+                                 ends_at=datetime.now() + timedelta(1))
+
+        session.session.execute(radgroup_property_mappings.insert(values=[
+            {'property': 'blocked_by_finance', 'radgroup': 'finance'},
+            {'property': 'blocked_by_traffic', 'radgroup': 'traffic'},
+        ]))
+
+    def test_radcheck(self):
+        # <mac> - <nasip> - <nasport> - "Cleartext-Password" - := - <mac> - 10
+        # We have one interface with a MAC whose room has two ports on the same switch
+        rows = session.session.query(radcheck.table).all()
+        host = self.user.hosts[0]
+        mac = host.interfaces[0].mac
+        for row in rows:
+            self.assertEqual(row.username, mac)
+            self.assertEqual(row.nasipaddress, self.switch.management_ip)
+            self.assertEqual(row.attribute, "Cleartext-Password")
+            self.assertEqual(row.op, ":=")
+            self.assertEqual(row.value, mac)
+            self.assertEqual(row.priority, 10)
+
+        self.assertEqual({row.nasportid for row in rows},
+                         {port.switch_port.name for port in host.room.patch_ports})
+
+    # TODO: Put Entries in some basetable to test tagged vlans (separate test)
+    # TODO: test radreply, radgroupreply (with base, see above), radgroupcheck

--- a/tests/model/test_hades.py
+++ b/tests/model/test_hades.py
@@ -52,14 +52,14 @@ class HadesViewTest(FactoryDataTestBase):
         host = self.user.hosts[0]
         mac = host.interfaces[0].mac
         for row in rows:
-            self.assertEqual(row.username, mac)
-            self.assertEqual(row.nasipaddress, self.switch.management_ip)
-            self.assertEqual(row.attribute, "Cleartext-Password")
-            self.assertEqual(row.op, ":=")
-            self.assertEqual(row.value, mac)
-            self.assertEqual(row.priority, 10)
+            self.assertEqual(row.UserName, mac)
+            self.assertEqual(row.NASIPAddress, self.switch.management_ip)
+            self.assertEqual(row.Attribute, "Cleartext-Password")
+            self.assertEqual(row.Op, ":=")
+            self.assertEqual(row.Value, mac)
+            self.assertEqual(row.Priority, 10)
 
-        self.assertEqual({row.nasportid for row in rows},
+        self.assertEqual({row.NASPortId for row in rows},
                          {port.switch_port.name for port in host.room.patch_ports})
 
     # TODO: Put Entries in some basetable to test tagged vlans (separate test)

--- a/tests/model/test_hades.py
+++ b/tests/model/test_hades.py
@@ -54,9 +54,9 @@ class HadesViewTest(FactoryDataTestBase):
         for row in rows:
             self.assertEqual(row.UserName, mac)
             self.assertEqual(row.NASIPAddress, self.switch.management_ip)
-            self.assertEqual(row.Attribute, "Cleartext-Password")
-            self.assertEqual(row.Op, ":=")
-            self.assertEqual(row.Value, mac)
+            self.assertEqual(row.Attribute, "User-Name")
+            self.assertEqual(row.Op, "=*")
+            self.assertEqual(row.Value, None)
             self.assertEqual(row.Priority, 10)
 
         self.assertEqual({row.NASPortId for row in rows},

--- a/tests/model/test_hades.py
+++ b/tests/model/test_hades.py
@@ -1,7 +1,7 @@
 from datetime import datetime, timedelta
 
 from pycroft.model import session
-from pycroft.model.hades import radgroup_property_mappings, radcheck
+from pycroft.model.hades import radius_property, radcheck
 from tests import FactoryDataTestBase
 from tests.factories import PropertyGroupFactory, MembershipFactory, UserWithHostFactory, \
     SwitchFactory, PatchPortFactory
@@ -14,14 +14,14 @@ class HadesViewTest(FactoryDataTestBase):
             name="Member",
             granted={'network_access'},
         )
-        self.blocked_by_finance_group = PropertyGroupFactory.create(
+        self.payment_in_default_group = PropertyGroupFactory.create(
             name="Blocked (finance)",
-            granted={'blocked_by_finance'},
+            granted={'payment_in_default'},
             denied={'network_access'},
         )
-        self.blocked_by_traffic_group = PropertyGroupFactory.create(
+        self.traffic_limit_exceeded_group = PropertyGroupFactory.create(
             name="Blocked (traffic)",
-            granted={'blocked_by_traffic'},
+            granted={'traffic_limit_exceeded'},
             denied={'network_access'},
         )
 
@@ -36,13 +36,13 @@ class HadesViewTest(FactoryDataTestBase):
         MembershipFactory.create(user=self.user, group=self.network_access_group,
                                  begins_at=datetime.now() + timedelta(-1),
                                  ends_at=datetime.now() + timedelta(1))
-        MembershipFactory.create(user=self.user, group=self.blocked_by_finance_group,
+        MembershipFactory.create(user=self.user, group=self.payment_in_default_group,
                                  begins_at=datetime.now() + timedelta(-1),
                                  ends_at=datetime.now() + timedelta(1))
 
-        session.session.execute(radgroup_property_mappings.insert(values=[
-            {'property': 'blocked_by_finance', 'radgroup': 'finance'},
-            {'property': 'blocked_by_traffic', 'radgroup': 'traffic'},
+        session.session.execute(radius_property.insert(values=[
+            ('payment_in_default',),
+            ('traffic_limit_exceeded',),
         ]))
 
     def test_radcheck(self):


### PR DESCRIPTION
Fixes #101 

Left to do (following @sebschrader):

- [x] Remove Reply-Message reply items
- [x] Use case-sensitive column names for Hades views
- [x] Direct mapping from property name to group names
- [x] Use better names for the blocking properties (traffic_limit_exceeded, payment_in_default, no_network_access)
- [x] Add radgroupreply items for blocking properties
- [x] Set Fall-Through to yes for regular groups
- [x] Add (&& fill) the `radius_property`, `radgroupreply_base`
      and `nas` tables (the latter without secret)
- [x] Add the blocking groups in the importer
- [x] Add integration tests for each table, as started
- [x] Add view `dhcphost`: `Mac | IpAddress` && test
- [x] Add view `alternative_dns`: `IpAddress` && test