### PR TITLE
fixed importer

### DIFF
--- a/legacy/netusers_model.py
+++ b/legacy/netusers_model.py
@@ -8,6 +8,7 @@ from sqlalchemy import (Column, Date, DateTime, Enum, Index,
 from sqlalchemy.dialects.postgresql import INET
 from sqlalchemy.ext.hybrid import hybrid_property
 from sqlalchemy.ext.declarative import declarative_base
+from sqlalchemy.orm import relationship
 
 Base = declarative_base()
 metadata = Base.metadata


### PR DESCRIPTION
Doing the legacy import failed with
```
Traceback (most recent call last):
  File "/usr/lib/python3.4/runpy.py", line 170, in _run_module_as_main
    "__main__", mod_spec)
  File "/usr/lib/python3.4/runpy.py", line 85, in _run_code
    exec(code, run_globals)
  File "/pycroft/legacy/import_legacy.py", line 40, in <module>
    from . import netusers_model
  File "/pycroft/legacy/netusers_model.py", line 28, in <module>
    class Nutzer(Base):
  File "/pycroft/legacy/netusers_model.py", line 60, in Nutzer
    computer = relationship("Computer", backref="nutzer")
NameError: name 'relationship' is not defined
```

so I imported `relationship` from `sqlalchemy.orm`