### PR TITLE
Retrieve bank account transactions via FinTS

### DIFF
--- a/legacy/translate.py
+++ b/legacy/translate.py
@@ -348,6 +348,7 @@ def generate_bank_account(data, resources):
         iban="DE61850503003120219540",
         bic="OSDDDE81XXX",
         fints_endpoint="https://banking-sn5.s-fints-pt-sn.de/fints30",
+        last_import=None,
         account=an_d["Bankkonto"])
 
     resources['bank_account'] = bank_account

--- a/legacy/translate.py
+++ b/legacy/translate.py
@@ -348,7 +348,6 @@ def generate_bank_account(data, resources):
         iban="DE61850503003120219540",
         bic="OSDDDE81XXX",
         fints_endpoint="https://banking-sn5.s-fints-pt-sn.de/fints30",
-        last_import=None,
         account=an_d["Bankkonto"])
 
     resources['bank_account'] = bank_account

--- a/legacy/translate.py
+++ b/legacy/translate.py
@@ -347,6 +347,7 @@ def generate_bank_account(data, resources):
         routing_number="85050300",
         iban="DE61850503003120219540",
         bic="OSDDDE81XXX",
+        fints_endpoint="https://banking-sn5.s-fints-pt-sn.de/fints30",
         account=an_d["Bankkonto"])
 
     resources['bank_account'] = bank_account

--- a/pycroft/model/finance.py
+++ b/pycroft/model/finance.py
@@ -12,8 +12,6 @@ from sqlalchemy.schema import (
 from sqlalchemy.types import (
     Date, DateTime, Enum, Integer, Interval, String, Text)
 
-from datetime import datetime
-
 from pycroft.helpers.i18n import gettext
 from pycroft.helpers.interval import closed
 from pycroft.model import ddl
@@ -229,7 +227,7 @@ class BankAccount(IntegerIdModel):
     @hybrid_property
     def last_updated_at(self):
         if not self.activities:
-            return datetime(2018,1,1)
+            return None
         else:
             return max(act.imported_at for act in self.activities)
 
@@ -267,6 +265,7 @@ class BankAccountActivity(IntegerIdModel):
     split = relationship(Split, foreign_keys=(transaction_id, account_id),
                          backref=backref("bank_account_activity",
                                          uselist=False))
+
     __table_args = (
         ForeignKeyConstraint((transaction_id, account_id),
                              (Split.transaction_id, Split.account_id),

--- a/pycroft/model/finance.py
+++ b/pycroft/model/finance.py
@@ -214,6 +214,8 @@ class BankAccount(IntegerIdModel):
     iban = Column(String(34), nullable=False)
     bic = Column(String(11), nullable=False)
     fints_endpoint = Column(String, nullable=False)
+    last_import = Column(Date, nullable=True) # date on which last finance-
+                                              # import was done
     account_id = Column(Integer, ForeignKey(Account.id), nullable=False,
                         unique=True)
     account = relationship(Account)

--- a/pycroft/model/finance.py
+++ b/pycroft/model/finance.py
@@ -12,12 +12,15 @@ from sqlalchemy.schema import (
 from sqlalchemy.types import (
     Date, DateTime, Enum, Integer, Interval, String, Text)
 
+from datetime import datetime
+
 from pycroft.helpers.i18n import gettext
 from pycroft.helpers.interval import closed
 from pycroft.model import ddl
 from pycroft.model.types import Money
 from .base import IntegerIdModel
 from .functions import utcnow
+
 
 manager = ddl.DDLManager()
 
@@ -226,7 +229,7 @@ class BankAccount(IntegerIdModel):
     @hybrid_property
     def last_updated_at(self):
         if not self.activities:
-            return None
+            return datetime(2018,1,1)
         else:
             return max(act.imported_at for act in self.activities)
 

--- a/pycroft/model/finance.py
+++ b/pycroft/model/finance.py
@@ -213,6 +213,7 @@ class BankAccount(IntegerIdModel):
     routing_number = Column(String(8), nullable=False)
     iban = Column(String(34), nullable=False)
     bic = Column(String(11), nullable=False)
+    fints_endpoint = Column(String, nullable=False)
     account_id = Column(Integer, ForeignKey(Account.id), nullable=False,
                         unique=True)
     account = relationship(Account)

--- a/pycroft/model/finance.py
+++ b/pycroft/model/finance.py
@@ -214,8 +214,6 @@ class BankAccount(IntegerIdModel):
     iban = Column(String(34), nullable=False)
     bic = Column(String(11), nullable=False)
     fints_endpoint = Column(String, nullable=False)
-    last_import = Column(Date, nullable=True) # date on which last finance-
-                                              # import was done
     account_id = Column(Integer, ForeignKey(Account.id), nullable=False,
                         unique=True)
     account = relationship(Account)

--- a/pycroft/model/finance.py
+++ b/pycroft/model/finance.py
@@ -227,7 +227,10 @@ class BankAccount(IntegerIdModel):
 
     @hybrid_property
     def last_updated_at(self):
-        return max(act.imported_at for act in self.activities)
+        if not self.activities:
+            return None
+        else:
+            return max(act.imported_at for act in self.activities)
 
     @last_updated_at.expression
     def last_updated_at(self):

--- a/pycroft/model/finance.py
+++ b/pycroft/model/finance.py
@@ -226,10 +226,7 @@ class BankAccount(IntegerIdModel):
 
     @hybrid_property
     def last_updated_at(self):
-        if not self.activities:
-            return None
-        else:
-            return max(act.imported_at for act in self.activities)
+        return max((act.imported_at for act in self.activities), default=None)
 
     @last_updated_at.expression
     def last_updated_at(self):

--- a/tests/fixtures/dummy/finance.py
+++ b/tests/fixtures/dummy/finance.py
@@ -69,4 +69,5 @@ class BankAccountData(DataSet):
         routing_number = "12345678"
         iban = "DE61123456781020304050"
         bic = "ABCDEFGH123"
+        fints_endpoint="https://example.org/fints"
         account = AccountData.bank_account

--- a/tests/lib/finance_fixtures.py
+++ b/tests/lib/finance_fixtures.py
@@ -154,4 +154,5 @@ class BankAccountData(DataSet):
         routing_number = "85050300"
         iban = "DE61850503003120219540"
         bic = "OSDDDE81XXX"
+        fints_endpoint="https://example.org/fints"
         account = AccountData.bank_account

--- a/vagrant/requirements.txt
+++ b/vagrant/requirements.txt
@@ -30,3 +30,4 @@ alembic~=0.9.6
 simplejson~=3.11.1
 #usersheet generation
 reportlab~=3.4.0
+fints

--- a/vagrant/requirements.txt
+++ b/vagrant/requirements.txt
@@ -30,4 +30,4 @@ alembic~=0.9.6
 simplejson~=3.11.1
 #usersheet generation
 reportlab~=3.4.0
-fints
+fints~=0.2.1

--- a/web/blueprints/finance/__init__.py
+++ b/web/blueprints/finance/__init__.py
@@ -134,23 +134,23 @@ def bank_accounts_import():
     old_transactions = [] # transactions which are already imported
     if form.validate_on_submit():
         # login with fints
-        bankaccount = BankAccount.q.get(form.account.data)
+        bank_account = BankAccount.q.get(form.account.data)
         try:
             fints = FinTS3PinTanClient(
-                bankaccount.routing_number,
+                bank_account.routing_number,
                 form.user.data,
                 form.pin.data,
-                bankaccount.fints_endpoint
+                bank_account.fints_endpoint
             )
 
             acc = next((a for a in fints.get_sepa_accounts()
-                        if a.iban == bankaccount.iban), None)
+                        if a.iban == bank_account.iban), None)
             if acc is None:
                 raise KeyError('BankAccount with IBAN {} not found.'.format(
-                    bankaccount.iban)
+                    bank_account.iban)
                 )
-            if bankaccount.last_updated_at is not None:
-                start_date = bankaccount.last_updated_at.date()
+            if bank_account.last_updated_at is not None:
+                start_date = bank_account.last_updated_at.date()
             else:
                 start_date = date(2018,1,1)
             statement = fints.get_statement(acc, start_date, date.today())
@@ -173,7 +173,7 @@ def bank_accounts_import():
             other_name = transaction.data['applicant_name'] if \
                 transaction.data['applicant_name'] is not None else ''
             new_activity = BankAccountActivity(
-                bank_account_id=bankaccount.id,
+                bank_account_id=bank_account.id,
                 amount=int(transaction.data['amount'].amount*100),
                 reference=transaction.data['purpose'],
                 original_reference=transaction.data['purpose'],
@@ -207,7 +207,7 @@ def bank_accounts_import():
             session.commit()
             flash(u'Bankkontobewegungen wurden importiert.')
             return redirect(url_for(".accounts_show",
-                                    account_id=bankaccount.account_id))
+                                    account_id=bank_account.account_id))
 
 
     return render_template('finance/bank_accounts_import.html', form=form,

--- a/web/blueprints/finance/__init__.py
+++ b/web/blueprints/finance/__init__.py
@@ -154,7 +154,7 @@ def bank_accounts_create():
         )
         session.add(new_bank_account)
         session.commit()
-        return redirect(url_for('.bank_accounts'))
+        return redirect(url_for('.bank_accounts_list'))
 
     return render_template('finance/bank_accounts_create.html',
                            form=form, page_title=u"Bankkonto erstellen")

--- a/web/blueprints/finance/__init__.py
+++ b/web/blueprints/finance/__init__.py
@@ -200,6 +200,7 @@ def bank_accounts_import():
                 transactions.append(new_activity)
             else:
                 old_transactions.append(new_activity)
+
         if form.do_import.data is True:
             # save transactions to database
             session.add_all(transactions)

--- a/web/blueprints/finance/__init__.py
+++ b/web/blueprints/finance/__init__.py
@@ -143,11 +143,8 @@ def bank_accounts_import():
                 bankaccount.fints_endpoint
             )
 
-            acc = None
-            for account in fints.get_sepa_accounts():
-                if account.iban == bankaccount.iban:
-                    acc = account
-                    break
+            acc = next((a for a in fints.get_sepa_accounts()
+                        if a.iban == bankaccount.iban), None)
             if acc is None:
                 raise KeyError('BankAccount with IBAN {} not found.'.format(
                     bankaccount.iban)

--- a/web/blueprints/finance/forms.py
+++ b/web/blueprints/finance/forms.py
@@ -8,7 +8,7 @@ from wtforms import Form as WTForm, ValidationError
 from wtforms.validators import DataRequired, NumberRange, Optional
 
 from web.form.fields.core import (
-    TextField, IntegerField, HiddenField, FileField, SelectField, FormField,
+    TextField, IntegerField, HiddenField, BooleanField, SelectField, FormField,
     FieldList, StringField, DateField, MoneyField, PasswordField)
 from web.form.fields.custom import TypeaheadField, static, disabled
 from pycroft.helpers.i18n import gettext
@@ -97,6 +97,7 @@ class BankAccountActivitiesImportForm(Form):
     account = SelectField(u"Bankkonto", coerce=int)
     user = StringField(u"Loginname", validators=[DataRequired()])
     pin = PasswordField(u"PIN", validators=[DataRequired()])
+    do_import = BooleanField(u"Import durchführen", default=False)
 
 
 class AccountCreateForm(Form):

--- a/web/blueprints/finance/forms.py
+++ b/web/blueprints/finance/forms.py
@@ -9,7 +9,7 @@ from wtforms.validators import DataRequired, NumberRange, Optional
 
 from web.form.fields.core import (
     TextField, IntegerField, HiddenField, FileField, SelectField, FormField,
-    FieldList, StringField, DateField, MoneyField)
+    FieldList, StringField, DateField, MoneyField, PasswordField)
 from web.form.fields.custom import TypeaheadField, static, disabled
 from pycroft.helpers.i18n import gettext
 from pycroft.model.finance import BankAccount
@@ -73,6 +73,7 @@ class BankAccountCreateForm(Form):
     routing_number = TextField(u"Bankleitzahl (BLZ)")
     iban = TextField(u"IBAN")
     bic = TextField(u"BIC")
+    fints = TextField(u"FinTS-Endpunkt", default="https://mybank.com/…")
 
     def validate_iban(self, field):
         if BankAccount.q.filter_by(iban=field.data ).first() is not None:
@@ -93,8 +94,9 @@ class BankAccountActivityEditForm(Form):
 
 
 class BankAccountActivitiesImportForm(Form):
-    expected_balance = IntegerField(u"Erwarteter Kontostand")
-    csv_file = FileField(u"Umsätze (CSV-MT940)")
+    account = SelectField(u"Bankkonto", coerce=int)
+    user = StringField(u"Loginname", validators=[DataRequired()])
+    pin = PasswordField(u"PIN", validators=[DataRequired()])
 
 
 class AccountCreateForm(Form):

--- a/web/blueprints/finance/forms.py
+++ b/web/blueprints/finance/forms.py
@@ -12,6 +12,7 @@ from web.form.fields.core import (
     FieldList, StringField, DateField, MoneyField)
 from web.form.fields.custom import TypeaheadField, static, disabled
 from pycroft.helpers.i18n import gettext
+from pycroft.model.finance import BankAccount
 
 class SemesterCreateForm(Form):
     name = TextField(u"Semestername", validators=[DataRequired()])
@@ -73,6 +74,9 @@ class BankAccountCreateForm(Form):
     iban = TextField(u"IBAN")
     bic = TextField(u"BIC")
 
+    def validate_iban(self, field):
+        if BankAccount.q.filter_by(iban=field.data ).first() is not None:
+            raise ValidationError("Konto existiert bereits.")
 
 class BankAccountActivityEditForm(Form):
     account = TypeaheadField(u"Gegenkonto")

--- a/web/templates/finance/bank_accounts_import.html
+++ b/web/templates/finance/bank_accounts_import.html
@@ -12,6 +12,7 @@
     {{ forms.upload_form(form, '', url_for('.bank_accounts_list')) }}
 
     {% if transactions %}
+        Folgende Bewegungen werden importiert:
         <table class="table table-striped">
         <tr>
             <th>Betrag</th>
@@ -21,6 +22,27 @@
             <th>Datum</th>
         </tr>
         {% for transaction in transactions %}
+            <tr>
+                <td>{{ transaction.amount }}</td>
+                <td>{{ transaction.reference }}</td>
+                <td>{{ transaction.other_account_number }}</td>
+                <td>{{ transaction.other_name }}</td>
+                <td>{{ transaction.valid_on }}</td>
+            </tr>
+        {% endfor %}
+        </table>
+    {% endif %}
+    {% if old_transactions %}
+        Folgende Bewegungen wurden bereits früher importiert:
+        <table class="table table-striped">
+        <tr>
+            <th>Betrag</th>
+            <th>Verwendungszweck</th>
+            <th>IBAN</th>
+            <th>Name</th>
+            <th>Datum</th>
+        </tr>
+        {% for transaction in old_transactions %}
             <tr>
                 <td>{{ transaction.amount }}</td>
                 <td>{{ transaction.reference }}</td>

--- a/web/templates/finance/bank_accounts_import.html
+++ b/web/templates/finance/bank_accounts_import.html
@@ -7,6 +7,29 @@
 {% import "macros/forms.html" as forms %}
 {% set page_title = "Bankkontobewegungen importieren" %}
 
+{% import "macros/forms.html" as forms %}
 {% block single_row_content %}
     {{ forms.upload_form(form, '', url_for('.bank_accounts_list')) }}
+
+    {% if transactions %}
+        <table class="table table-striped">
+        <tr>
+            <th>Betrag</th>
+            <th>Verwendungszweck</th>
+            <th>IBAN</th>
+            <th>Name</th>
+            <th>Datum</th>
+        </tr>
+        {% for transaction in transactions %}
+            <tr>
+                <td>{{ transaction.amount }}</td>
+                <td>{{ transaction.reference }}</td>
+                <td>{{ transaction.other_account_number }}</td>
+                <td>{{ transaction.other_name }}</td>
+                <td>{{ transaction.valid_on }}</td>
+            </tr>
+        {% endfor %}
+        </table>
+    {% endif %}
+
 {% endblock %}


### PR DESCRIPTION
Bank account transactions can now be imported via FinTS. The credentials for logging into the bank account are not saved anywhere (except the FinTS-URI).
Before importing all potentially new transactions, they're checked if they are new transactions. Potentially new are those transactions, which took place on the day of the last import or later.

With this PR also a bug, which occurred while listing all existing bank accounts when one of those hasn't had any transactions, was fixed.

Closes #182