### PR TITLE
Switch to timestamp with timezone

### DIFF
--- a/helpers/interactive.py
+++ b/helpers/interactive.py
@@ -17,9 +17,9 @@ and initializes the session.
 import os
 
 from flask import _request_ctx_stack
-from sqlalchemy import create_engine
 from sqlalchemy.orm import scoped_session, sessionmaker
 
+from pycroft.model import create_engine
 from pycroft.model.session import set_scoped_session
 from pycroft.model._all import *
 from pycroft import config

--- a/ldap_sync/exporter.py
+++ b/ldap_sync/exporter.py
@@ -6,9 +6,10 @@ import sys
 from collections import Counter, defaultdict, namedtuple
 
 import ldap3
-from sqlalchemy import create_engine, func
+from sqlalchemy import func
 from sqlalchemy.orm import scoped_session, sessionmaker
 
+from pycroft.model import create_engine
 from pycroft.model.user import User
 from pycroft.model.session import set_scoped_session, session as global_session
 from .record import Record, RecordState

--- a/legacy/import_legacy.py
+++ b/legacy/import_legacy.py
@@ -33,8 +33,9 @@ except ImportError:
 os.environ['PYCROFT_DB_URI'] = conn_opts['pycroft']
 sys.path.append(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 from pycroft import model, property
-from pycroft.model import (traffic, facilities, user, net, port,
-                           finance, session, host, config, logging, types)
+from pycroft.model import (create_engine as pyc_create_engine, traffic,
+                           facilities, user, net, port, finance, session, host,
+                           config, logging, types)
 
 from . import userman_model
 from . import netusers_model
@@ -86,7 +87,7 @@ def translate_all(data):
 
 def import_legacy(args):
     """Import the legacy data according to ``args``"""
-    engine = create_engine(os.environ['PYCROFT_DB_URI'], echo=False)
+    engine = pyc_create_engine(os.environ['PYCROFT_DB_URI'], echo=False)
     session.set_scoped_session(
         scoped_session(sessionmaker(bind=engine),
                        scopefunc=lambda: _request_ctx_stack.top))

--- a/legacy_gerok/import_gerok.py
+++ b/legacy_gerok/import_gerok.py
@@ -34,8 +34,9 @@ except ImportError:
 os.environ['PYCROFT_DB_URI'] = conn_opts['pycroft']
 sys.path.append(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 from pycroft import model
-from pycroft.model import (facilities, user, net, port, traffic,
-                           finance, session, host, config, logging)
+from pycroft.model import (create_engine as pyc_create_engine, facilities, user,
+                           net, port, traffic, finance, session, host, config,
+                           logging)
 from pycroft.helpers import user as usertools
 
 from legacy.import_conf import group_props
@@ -61,7 +62,7 @@ def exists_db(connection, name):
 
 def main(args):
     """Import the legacy data according to ``args``"""
-    engine = create_engine(os.environ['PYCROFT_DB_URI'], echo=False)
+    engine = pyc_create_engine(os.environ['PYCROFT_DB_URI'], echo=False)
     session.set_scoped_session(
         scoped_session(sessionmaker(bind=engine),
                        scopefunc=lambda: _request_ctx_stack.top))

--- a/pycroft/lib/finance.py
+++ b/pycroft/lib/finance.py
@@ -631,7 +631,7 @@ def process_transactions(bank_account, statement):
             other_account_number=iban,
             other_routing_number=bic,
             other_name=other_name,
-            imported_at=datetime.now(),
+            imported_at=session.utcnow(),
             posted_on=transaction.data['entry_date'],
             valid_on=transaction.data['date'],
         )

--- a/pycroft/lib/user.py
+++ b/pycroft/lib/user.py
@@ -110,7 +110,7 @@ def store_user_sheet(new_user, plain_password, timeout=15):
     """
     pdf_data = b64encode(generate_user_sheet(new_user, plain_password)).decode('ascii')
     pdf_storage = WebStorage(data=pdf_data,
-                             expiry=datetime.utcnow() + timedelta(minutes=timeout))
+                             expiry=session.utcnow() + timedelta(minutes=timeout))
     session.session.add(pdf_storage)
 
     return pdf_storage
@@ -465,7 +465,7 @@ def traffic_events_expr():
     return events
 
 
-def traffic_balance_expr(until=func.now()):
+def traffic_balance_expr(until=func.current_timestamp()):
     # not a hybrid attribute expression due to circular import dependencies
 
     balance = select(

--- a/pycroft/model/__init__.py
+++ b/pycroft/model/__init__.py
@@ -14,6 +14,16 @@ from . import _all
 from . import base
 from . import session
 
+import os
+from sqlalchemy import create_engine as sqa_create_engine
+
+
+def create_engine(connection_string, **kwargs):
+    kwargs.setdefault('connect_args', {}).update(
+        options="-c TimeZone=UTC"
+    )
+    return sqa_create_engine(connection_string, **kwargs)
+
 
 def create_db_model(bind):
     """Create all models in the database.

--- a/pycroft/model/finance.py
+++ b/pycroft/model/finance.py
@@ -11,15 +11,13 @@ from sqlalchemy.ext.hybrid import hybrid_property
 from sqlalchemy.orm import relationship, backref
 from sqlalchemy.schema import (
     CheckConstraint, ForeignKeyConstraint, UniqueConstraint)
-from sqlalchemy.types import (
-    Date, DateTime, Enum, Integer, Interval, String, Text)
+from sqlalchemy.types import Date, Enum, Integer, Interval, String, Text
 
 from pycroft.helpers.i18n import gettext
 from pycroft.helpers.interval import closed
 from pycroft.model import ddl
-from pycroft.model.types import Money
+from pycroft.model.types import Money, DateTimeTz
 from .base import IntegerIdModel
-from .functions import utcnow
 
 
 manager = ddl.DDLManager()
@@ -152,9 +150,11 @@ class Transaction(IntegerIdModel):
                                            onupdate='CASCADE'),
                        nullable=True)
     author = relationship("User")
-    posted_at = Column(DateTime, nullable=False,
-                       default=utcnow(), onupdate=utcnow())
-    valid_on = Column(Date, nullable=False, default=utcnow(), index=True)
+    posted_at = Column(DateTimeTz, nullable=False,
+                       server_default=func.current_timestamp(),
+                       onupdate=func.current_timestamp())
+    valid_on = Column(Date, nullable=False,
+                      server_default=func.current_timestamp(), index=True)
     accounts = relationship(Account, secondary="split", backref="transactions")
 
     @property
@@ -300,7 +300,7 @@ class BankAccountActivity(IntegerIdModel):
     other_account_number = Column(String(255), nullable=False)
     other_routing_number = Column(String(255), nullable=False)
     other_name = Column(String(255), nullable=False)
-    imported_at = Column(DateTime, nullable=False)
+    imported_at = Column(DateTimeTz, nullable=False)
     posted_on = Column(Date, nullable=False)
     valid_on = Column(Date, nullable=False)
     transaction_id = Column(Integer, ForeignKey(Transaction.id,

--- a/pycroft/model/functions.py
+++ b/pycroft/model/functions.py
@@ -10,7 +10,7 @@ from sqlalchemy.ext.compiler import compiles
 from sqlalchemy.sql import expression
 from sqlalchemy.sql.functions import max as sa_max
 from sqlalchemy.sql.functions import min as sa_min
-from sqlalchemy.types import DateTime, Numeric, Integer
+from sqlalchemy.types import Numeric, Integer
 
 
 class greatest(expression.FunctionElement):

--- a/pycroft/model/functions.py
+++ b/pycroft/model/functions.py
@@ -28,20 +28,6 @@ class sign(expression.FunctionElement):
     name = 'sign'
 
 
-class utcnow(expression.FunctionElement):
-    type = DateTime
-
-
-@compiles(utcnow, 'postgresql')
-def pg_utcnow(element, compiler, **kw):
-    return "TIMEZONE('utc', STATEMENT_TIMESTAMP())"
-
-
-@compiles(utcnow, 'sqlite')
-def sqlite_utcnow(element, compiler, **kw):
-    return "STRFTIME('%Y-%m-%d %H:%M:%f000', 'now')"
-
-
 @compiles(greatest)
 @compiles(least)
 @compiles(sign)

--- a/pycroft/model/logging.py
+++ b/pycroft/model/logging.py
@@ -10,11 +10,11 @@
 
     :copyright: (c) 2011 by AG DSN.
 """
-from sqlalchemy import Column, ForeignKey
+from sqlalchemy import Column, ForeignKey, func
 from sqlalchemy.orm import relationship, backref
-from sqlalchemy.types import Integer, DateTime, Text, String
+from sqlalchemy.types import Integer, Text, String
 from pycroft.model.base import IntegerIdModel
-from pycroft.model.functions import utcnow
+from pycroft.model.types import DateTimeTz
 
 
 class LogEntry(IntegerIdModel):
@@ -24,7 +24,7 @@ class LogEntry(IntegerIdModel):
     # variably sized string
     message = Column(Text, nullable=False)
     # created
-    created_at = Column(DateTime, nullable=False, default=utcnow())
+    created_at = Column(DateTimeTz, nullable=False, server_default=func.current_timestamp())
 
     # many to one from LogEntry to User
     author = relationship("User",

--- a/pycroft/model/property.py
+++ b/pycroft/model/property.py
@@ -18,7 +18,6 @@ from sqlalchemy.orm import Query
 
 from .base import ModelBase
 from .ddl import View, DDLManager
-from .functions import utcnow as utcnow_sql
 from .user import User, Property, Membership, PropertyGroup
 
 manager = DDLManager()
@@ -77,7 +76,7 @@ current_property = View(
     query=(
         select([literal_column('user_id'), literal_column('property_name'),
                 literal_column('denied')])
-        .select_from(func.evaluate_properties(utcnow_sql()))
+        .select_from(func.evaluate_properties(func.current_timestamp()))
     ),
 )
 manager.add_view(Membership.__table__, current_property)

--- a/pycroft/model/session.py
+++ b/pycroft/model/session.py
@@ -14,7 +14,7 @@
 from werkzeug.local import LocalProxy
 import wrapt
 
-from .functions import utcnow as utcnow_sql
+from sqlalchemy import func
 
 
 class NullScopedSession(object):
@@ -51,4 +51,4 @@ def with_transaction(wrapped, instance, args, kwargs):
 
 
 def utcnow():
-    return session.query(utcnow_sql()).scalar()
+    return session.query(func.current_timestamp()).scalar()

--- a/pycroft/model/traffic.py
+++ b/pycroft/model/traffic.py
@@ -5,13 +5,12 @@
 from sqlalchemy import Column, ForeignKey, CheckConstraint, \
     PrimaryKeyConstraint, func, or_, and_, true
 from sqlalchemy.orm import relationship, backref, Query
-from sqlalchemy.types import BigInteger, Enum, Integer, DateTime
+from sqlalchemy.types import BigInteger, Enum, Integer
 
 from pycroft.model.base import ModelBase, IntegerIdModel
 from pycroft.model.ddl import DDLManager, Function, Trigger, View
-from pycroft.model.types import IPAddress
+from pycroft.model.types import IPAddress, DateTimeTz
 from pycroft.model.user import User
-from pycroft.model.functions import utcnow
 from pycroft.model.host import IP, Host, Interface
 
 ddl = DDLManager()
@@ -23,11 +22,11 @@ class TrafficBalance(ModelBase):
     user = relationship(User,
                         backref=backref("_traffic_balance", uselist=False))
     amount = Column(BigInteger, nullable=False)
-    timestamp = Column(DateTime, default=utcnow(), nullable=False)
+    timestamp = Column(DateTimeTz, server_default=func.current_timestamp(), nullable=False)
 
 
 class TrafficEvent(object):
-    timestamp = Column(DateTime, default=utcnow(), nullable=False)
+    timestamp = Column(DateTimeTz, server_default=func.current_timestamp(), nullable=False)
     amount = Column(BigInteger, CheckConstraint('amount >= 0'),
                     nullable=False)
 

--- a/pycroft/model/types.py
+++ b/pycroft/model/types.py
@@ -4,7 +4,7 @@
 from decimal import Decimal
 from numbers import Number
 import ipaddr
-from sqlalchemy import String, TypeDecorator, Integer
+from sqlalchemy import String, TypeDecorator, Integer, DateTime
 from sqlalchemy.dialects.postgresql import MACADDR, INET
 from pycroft.helpers.net import mac_regex
 
@@ -98,3 +98,8 @@ class Money(TypeDecorator):
 
 class InvalidMACAddressException(ValueError):
     pass
+
+
+class DateTimeTz(DateTime):
+    def __init__(self):
+        super().__init__(timezone=True)

--- a/pycroft/model/user.py
+++ b/pycroft/model/user.py
@@ -463,12 +463,14 @@ class Membership(IntegerIdModel):
                 "begins_at must be before ends_at"
         return value
 
-    def disable(self):
-        now = session.utcnow()
-        if self.begins_at is not None and self.begins_at > now:
+    def disable(self, ends_at=None):
+        if ends_at is None:
+            ends_at = session.utcnow()
+
+        if self.begins_at is not None and self.begins_at > ends_at:
             self.ends_at = self.begins_at
         else:
-            self.ends_at = now
+            self.ends_at = ends_at
 
 
 class PropertyGroup(Group):

--- a/pycroft/model/user.py
+++ b/pycroft/model/user.py
@@ -15,9 +15,9 @@ import re
 
 from flask_login import UserMixin
 from sqlalchemy import (
-    Boolean, BigInteger, CheckConstraint, Column, DateTime, ForeignKey, Integer,
+    Boolean, BigInteger, CheckConstraint, Column, ForeignKey, Integer,
     String, and_, exists, join, literal, not_, null, or_, select, Sequence,
-    Interval, Date)
+    Interval, Date, func)
 from sqlalchemy.ext.associationproxy import association_proxy
 from sqlalchemy.ext.hybrid import hybrid_method, hybrid_property
 from sqlalchemy.orm import backref, object_session, relationship, validates
@@ -31,6 +31,7 @@ from pycroft.helpers.interval import (
 from pycroft.helpers.user import hash_password, verify_password
 from pycroft.model import session, functions
 from pycroft.model.base import ModelBase, IntegerIdModel
+from pycroft.model.types import DateTimeTz
 
 
 class IllegalLoginError(ValueError):
@@ -44,7 +45,7 @@ class IllegalEmailError(ValueError):
 class User(IntegerIdModel, UserMixin):
     login = Column(String(40), nullable=False, unique=True)
     name = Column(String(255), nullable=False)
-    registered_at = Column(DateTime, nullable=False)
+    registered_at = Column(DateTimeTz, nullable=False)
     passwd_hash = Column(String)
     email = Column(String(255), nullable=True)
     birthdate = Column(Date, nullable=True)
@@ -389,8 +390,8 @@ class Group(IntegerIdModel):
 
 
 class Membership(IntegerIdModel):
-    begins_at = Column(DateTime, nullable=True, index=True, default=functions.utcnow())
-    ends_at = Column(DateTime, nullable=True, index=True)
+    begins_at = Column(DateTimeTz, nullable=True, index=True, server_default=func.current_timestamp())
+    ends_at = Column(DateTimeTz, nullable=True, index=True)
 
     # many to one from Membership to Group
     group_id = Column(Integer, ForeignKey(Group.id, ondelete="CASCADE"),

--- a/pycroft/model/user.py
+++ b/pycroft/model/user.py
@@ -421,7 +421,7 @@ class Membership(IntegerIdModel):
         :rtype: bool
         """
         if when is None:
-            now = object_session(self).query(functions.utcnow()).scalar()
+            now = session.utcnow()
             when = single(now)
 
         return when.overlaps(closed(self.begins_at, self.ends_at))

--- a/pycroft/model/user.py
+++ b/pycroft/model/user.py
@@ -465,7 +465,7 @@ class Membership(IntegerIdModel):
 
     def disable(self, ends_at=None):
         if ends_at is None:
-            ends_at = session.utcnow()
+            ends_at = object_session(self).query(func.current_timestamp()).scalar()
 
         if self.begins_at is not None and self.begins_at > ends_at:
             self.ends_at = self.begins_at

--- a/pycroft/model/user.py
+++ b/pycroft/model/user.py
@@ -421,7 +421,7 @@ class Membership(IntegerIdModel):
         :rtype: bool
         """
         if when is None:
-            now = session.utcnow()
+            now = object_session(self).query(func.current_timestamp()).scalar()
             when = single(now)
 
         return when.overlaps(closed(self.begins_at, self.ends_at))

--- a/pycroft/model/webstorage.py
+++ b/pycroft/model/webstorage.py
@@ -4,16 +4,16 @@
 # the Apache License, Version 2.0. See the LICENSE file for details.
 
 from pycroft.model.base import IntegerIdModel
-from sqlalchemy import Column, DateTime, Text
-from datetime import datetime
+from sqlalchemy import Column, Text, func
 from pycroft.model.session import session
+from pycroft.model.types import DateTimeTz
 
 class WebStorage(IntegerIdModel):
     data = Column(Text, nullable=False)
-    expiry = Column(DateTime, nullable=False)
+    expiry = Column(DateTimeTz, nullable=False)
 
     @staticmethod
     def auto_expire():
         """Delete all expired items from the database"""
-        WebStorage.q.filter(WebStorage.expiry <= datetime.utcnow()).delete(False)
+        WebStorage.q.filter(WebStorage.expiry <= func.current_timestamp()).delete(False)
         session.commit()

--- a/scripts/server_run.py
+++ b/scripts/server_run.py
@@ -9,13 +9,12 @@ from time import time
 
 from babel.support import Translations
 from flask import _request_ctx_stack, g, request
-from sqlalchemy import create_engine
 from sqlalchemy.orm import scoped_session, sessionmaker
 from werkzeug.contrib.profiler import ProfilerMiddleware
 
 import pycroft
 from pycroft.helpers.i18n import set_translation_lookup, get_locale
-from pycroft.model import create_db_model
+from pycroft.model import create_engine
 from pycroft.model.session import set_scoped_session
 import web
 from scripts.schema import AlembicHelper, SchemaStrategist
@@ -27,7 +26,6 @@ def server_run(args):
     except KeyError:
         raise RuntimeError("Environment variable PYCROFT_DB_URI must be "
                            "set to an SQLAlchemy connection string.")
-
     engine = create_engine(connection_string)
     connection = engine.connect()
     state = AlembicHelper(connection)

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -13,14 +13,13 @@ import flask_testing as testing
 from fixture.style import NamedDataStyle
 from fixture import SQLAlchemyFixture, DataTestCase
 from fixture.util import start_debug, stop_debug
-from sqlalchemy import create_engine
 from sqlalchemy.orm import sessionmaker, scoped_session
 from sqlalchemy.pool import SingletonThreadPool
 import sys
 
 from tests.factories import ConfigFactory, UserFactory, AdminPropertyGroupFactory, MembershipFactory
 from werkzeug.routing import IntegerConverter, UnicodeConverter
-from pycroft.model import session
+from pycroft.model import session, create_engine
 from pycroft.model import _all, drop_db_model, create_db_model
 
 

--- a/tests/lib/test_user.py
+++ b/tests/lib/test_user.py
@@ -293,24 +293,6 @@ class UserWithNetworkAccessTestCase(FixtureDataTestBase):
 
         self.assertFalse(user.member_of(config.violation_group, when=subinterval))
 
-    def test_instant_user_blocking_and_unblocking(self):
-        # TODO: test for log entries
-        u = self.user_to_block
-
-        blocked_user = UserHelper.suspend(u, reason=u"test", processor=u)
-        session.session.commit()
-        blocked_during = single(session.utcnow())
-
-        self.assertEqual(u.log_entries[0].author, blocked_user)
-        self.assert_violation_membership(blocked_user)
-        self.assert_violation_membership(blocked_user, subinterval=blocked_during)
-
-        unblocked_user = UserHelper.unblock(blocked_user, processor=u)
-        session.session.commit()
-
-        self.assertEqual(u.log_entries[0].author, unblocked_user)
-        self.assert_violation_membership(unblocked_user, subinterval=blocked_during)
-
     def test_deferred_blocking_and_unblocking_works(self):
         u = self.user_to_block
 

--- a/tests/model/test_property.py
+++ b/tests/model/test_property.py
@@ -103,7 +103,7 @@ class Test_010_PropertyResolving(PropertyDataTestBase):
     def test_0040_disable_membership(self):
         # add membership to group1
         membership = Membership(
-            begins_at=session.utcnow(),
+            begins_at=session.utcnow() - timedelta(hours=2),
             user=self.user,
             group=self.property_group1
         )
@@ -111,7 +111,7 @@ class Test_010_PropertyResolving(PropertyDataTestBase):
         session.session.commit()
 
         self.assertTrue(self.user.has_property(PropertyData.prop_test1.name))
-        membership.disable()
+        membership.disable(session.utcnow() - timedelta(hours=1))
         session.session.commit()
         self.assertNotIn(
             self.property_group1,
@@ -132,7 +132,7 @@ class Test_010_PropertyResolving(PropertyDataTestBase):
 
         # add membership to group2
         membership = Membership(
-            begins_at=session.utcnow(),
+            begins_at=session.utcnow() - timedelta(hours=2),
             user=self.user,
             group=self.property_group2
         )
@@ -143,7 +143,7 @@ class Test_010_PropertyResolving(PropertyDataTestBase):
         self.assertTrue(self.user.has_property(PropertyData.prop_test2.name))
 
         # disables membership in group2
-        membership.disable()
+        membership.disable(session.utcnow() - timedelta(hours=1))
         session.session.commit()
         self.assertTrue(self.user.has_property(PropertyData.prop_test1.name))
         self.assertFalse(self.user.has_property(PropertyData.prop_test2.name))
@@ -231,14 +231,15 @@ class Test_030_View_Only_Shortcut_Properties(PropertyDataTestBase):
         self.assertEqual(len(self.property_group1.active_users()), 0)
 
         # add membership to group1
-        p1 = Membership(user=self.user, group=self.property_group1)
+        p1 = Membership(begins_at=session.utcnow() - timedelta(hours=2),
+                        user=self.user, group=self.property_group1)
         session.session.add(p1)
         session.session.commit()
 
         self.assertEqual(len(self.property_group1.users), 1)
         self.assertEqual(len(self.property_group1.active_users()), 1)
 
-        p1.disable()
+        p1.disable(session.utcnow() - timedelta(hours=1))
         session.session.commit()
         self.assertEqual(len(self.property_group1.users), 1)
         self.assertEqual(len(self.property_group1.active_users()), 0)
@@ -249,7 +250,8 @@ class Test_030_View_Only_Shortcut_Properties(PropertyDataTestBase):
         self.assertEqual(len(self.user.active_traffic_groups()), 0)
 
         # add one active traffic group
-        p1 = Membership(user=self.user, group=self.traffic_group1)
+        p1 = Membership(begins_at=session.utcnow() - timedelta(hours=2),
+                        user=self.user, group=self.traffic_group1)
         session.session.add(p1)
         session.session.commit()
         f = Membership.q.first()
@@ -258,21 +260,23 @@ class Test_030_View_Only_Shortcut_Properties(PropertyDataTestBase):
         self.assertEqual(len(self.user.active_traffic_groups()), 1)
 
         # adding a property group should not affect the traffic_groups
-        p1 = Membership(user=self.user, group=self.property_group1)
+        p1 = Membership(begins_at=session.utcnow() - timedelta(hours=2),
+                        user=self.user, group=self.property_group1)
         session.session.add(p1)
         session.session.commit()
         self.assertEqual(len(self.user.traffic_groups), 1)
         self.assertEqual(len(self.user.active_traffic_groups()), 1)
 
         # add a second active traffic group - count should be 2
-        p2 = Membership(user=self.user, group=self.traffic_group2)
+        p2 = Membership(begins_at=session.utcnow() - timedelta(hours=2),
+                        user=self.user, group=self.traffic_group2)
         session.session.add(p2)
         session.session.commit()
         self.assertEqual(len(self.user.traffic_groups), 2)
         self.assertEqual(len(self.user.active_traffic_groups()), 2)
 
         # disable the second group. active should be one, all 2
-        p2.disable()
+        p2.disable(session.utcnow() - timedelta(hours=1))
         session.session.commit()
         self.assertEqual(len(self.user.traffic_groups), 2)
         self.assertEqual(len(self.user.active_traffic_groups()), 1)
@@ -294,14 +298,15 @@ class Test_030_View_Only_Shortcut_Properties(PropertyDataTestBase):
 
         # Add a second membership to the first group
         # should not affect the count
-        p1 = Membership(user=self.user, group=self.traffic_group1)
+        p1 = Membership(begins_at=session.utcnow() - timedelta(hours=2),
+                        user=self.user, group=self.traffic_group1)
         session.session.add(p1)
         session.session.commit()
         self.assertEqual(len(self.user.traffic_groups), 2)
         self.assertEqual(len(self.user.active_traffic_groups()), 2)
 
         # disabling the new one should also not affect.
-        p1.disable()
+        p1.disable(session.utcnow() - timedelta(hours=1))
         session.session.commit()
         self.assertEqual(len(self.user.traffic_groups), 2)
         self.assertEqual(len(self.user.active_traffic_groups()), 2)
@@ -321,7 +326,8 @@ class Test_030_View_Only_Shortcut_Properties(PropertyDataTestBase):
         self.assertEqual(len(self.user.active_property_groups()), 0)
 
         # add one active property group
-        p1 = Membership(user=self.user, group=self.property_group1)
+        p1 = Membership(begins_at=session.utcnow() - timedelta(hours=2),
+                        user=self.user, group=self.property_group1)
         session.session.add(p1)
         session.session.commit()
         f = Membership.q.first()
@@ -330,21 +336,23 @@ class Test_030_View_Only_Shortcut_Properties(PropertyDataTestBase):
         self.assertEqual(len(self.user.active_property_groups()), 1)
 
         # adding a traffic group should not affect the property_group
-        p1 = Membership(user=self.user, group=self.traffic_group2)
+        p1 = Membership(begins_at=session.utcnow() - timedelta(hours=2),
+                        user=self.user, group=self.traffic_group2)
         session.session.add(p1)
         session.session.commit()
         self.assertEqual(len(self.user.property_groups), 1)
         self.assertEqual(len(self.user.active_property_groups()), 1)
 
         # add a second active property group - count should be 2
-        p1 = Membership(user=self.user, group=self.property_group2)
+        p1 = Membership(begins_at=session.utcnow() - timedelta(hours=2),
+                        user=self.user, group=self.property_group2)
         session.session.add(p1)
         session.session.commit()
         self.assertEqual(len(self.user.property_groups), 2)
         self.assertEqual(len(self.user.active_property_groups()), 2)
 
         # disable the second group. active should be one, all 2
-        p1.disable()
+        p1.disable(session.utcnow() - timedelta(hours=1))
         session.session.commit()
         self.assertEqual(len(self.user.property_groups), 2)
         self.assertEqual(len(self.user.active_property_groups()), 1)
@@ -365,14 +373,15 @@ class Test_030_View_Only_Shortcut_Properties(PropertyDataTestBase):
 
         # Add a second membership to the first group
         # should not affect the count
-        p1 = Membership(user=self.user, group=self.property_group1)
+        p1 = Membership(begins_at=session.utcnow() - timedelta(hours=2),
+                        user=self.user, group=self.property_group1)
         session.session.add(p1)
         session.session.commit()
         self.assertEqual(len(self.user.property_groups), 2)
         self.assertEqual(len(self.user.active_property_groups()), 2)
 
         # disabling the new one should also not affect.
-        p1.disable()
+        p1.disable(session.utcnow() - timedelta(hours=1))
         session.session.commit()
         self.assertEqual(len(self.user.property_groups), 2)
         self.assertEqual(len(self.user.active_property_groups()), 2)
@@ -388,7 +397,8 @@ class Test_030_View_Only_Shortcut_Properties(PropertyDataTestBase):
 
 class Test_050_Membership(PropertyDataTestBase):
     def test_0010_active_instance_property(self):
-        p1 = Membership(user=self.user, group=self.property_group1)
+        p1 = Membership(begins_at=session.utcnow() - timedelta(hours=2),
+                        user=self.user, group=self.property_group1)
         self.assertTrue(p1.active())
         session.session.add(p1)
         session.session.commit()
@@ -398,7 +408,7 @@ class Test_050_Membership(PropertyDataTestBase):
         ).one()
         self.assertTrue(p1.active())
 
-        p1.disable()
+        p1.disable(session.utcnow() - timedelta(hours=1))
         session.session.commit()
 
         p1 = Membership.q.filter_by(
@@ -417,7 +427,8 @@ class Test_050_Membership(PropertyDataTestBase):
         session.session.delete(p1)
         session.session.commit()
 
-        p1 = Membership(user=self.user, group=self.property_group1)
+        p1 = Membership(begins_at=session.utcnow() - timedelta(hours=2),
+                        user=self.user, group=self.property_group1)
         session.session.add(p1)
         session.session.commit()
 
@@ -434,7 +445,7 @@ class Test_050_Membership(PropertyDataTestBase):
         ).one()
         self.assertFalse(p1.active())
 
-        p1.disable()
+        p1.disable(session.utcnow() - timedelta(hours=1))
         session.session.commit()
 
         p1 = Membership.q.filter_by(

--- a/tests/model/test_traffic.py
+++ b/tests/model/test_traffic.py
@@ -62,7 +62,7 @@ class PMAcctViewTest(FactoryDataTestBase):
                                                       stamp_inserted=stamp, stamp_updated=stamp))
         self.assertEqual(TrafficVolume.q.count(), 1)
         vol = TrafficVolume.q.one()
-        self.assertEqual(str(vol.timestamp), '2018-03-15 00:00:00')
+        self.assertEqual(str(vol.timestamp), '2018-03-15 00:00:00+00:00')
         self.assertEqual(vol.packets, sum(x[1] for x in data))
         self.assertEqual(vol.amount, sum(x[2] for x in data))
 
@@ -92,7 +92,7 @@ class PMAcctViewTest(FactoryDataTestBase):
                                                       stamp_inserted=stamp, stamp_updated=stamp))
         self.assertEqual(TrafficVolume.q.count(), 1)
         vol = TrafficVolume.q.one()
-        self.assertEqual(str(vol.timestamp), '2018-03-15 00:00:00')
+        self.assertEqual(str(vol.timestamp), '2018-03-15 00:00:00+00:00')
         self.assertEqual(vol.packets, sum(x[1] for x in data))
         self.assertEqual(vol.amount, sum(x[2] for x in data))
 


### PR DESCRIPTION
Task list taken from the corresponding issue #162:
- [x] Set the timezone connection parameter to `Etc/UTC`
- [x] Switch to `timestamp with timezone` everywhere in the model
- [x] Switch from `pycroft.model.functions.utcnow()` to `datetime.datetime.now(timezone.utc)` in the library
- [x] Replace usages of `pycroft.model.functions.utcnow()` in SQL expressions by `sqlalchemy.func.current_timestamp()`
- [ ] (Maybe optional, but recommended) Instruct `psycopg2` to return `datetime.timezone.utc`
- [ ] Verify the output of date and time in the web interface. Flask-Babel's [`format_datetime`](https://pythonhosted.org/Flask-Babel/#flask.ext.babel.format_datetime) should already do all the hard work. I think we're using it.