### PR TITLE
match unassigned bank-account activities

### DIFF
--- a/pycroft/lib/finance.py
+++ b/pycroft/lib/finance.py
@@ -15,7 +15,7 @@ import operator
 import re
 
 from sqlalchemy import or_, and_, literal_column, literal, select, exists, not_
-from sqlalchemy.orm import aliased, contains_eager
+from sqlalchemy.orm import aliased, contains_eager, joinedload
 from sqlalchemy.orm.exc import NoResultFound
 from sqlalchemy import func, between, Integer, cast
 
@@ -705,3 +705,22 @@ def build_transactions_query(account, search=None, sort_by='valid_on', sort_orde
         query = query.options(contains_eager(Split.transaction))
 
     return query
+
+def match_activities(BankAccount):
+    """Get a dict of all unmatched transactions and a user they should be matched with
+
+    :param BankAccount bank_account: The BankAccount to get the unmatched transactions from
+
+    :returns: Dictionary with transaction and user
+    :rtype: Dict
+    """
+
+    matching = {}
+    activity_q = (BankAccountActivity.q
+                  .options(joinedload(BankAccountActivity.bank_account))
+                  .filter(BankAccountActivity.transaction_id == None))
+    for activity in activity_q.all():
+        user = User.q.filter_by(login='beyerm').first()
+        matching.update({activity: user})
+
+    return matching

--- a/pycroft/lib/finance.py
+++ b/pycroft/lib/finance.py
@@ -714,13 +714,24 @@ def match_activities(BankAccount):
     :returns: Dictionary with transaction and user
     :rtype: Dict
     """
-
+    from pycroft.lib.user import check_user_id
     matching = {}
     activity_q = (BankAccountActivity.q
                   .options(joinedload(BankAccountActivity.bank_account))
                   .filter(BankAccountActivity.transaction_id == None))
     for activity in activity_q.all():
-        user = User.q.filter_by(login='beyerm').first()
-        matching.update({activity: user})
+        # search for user-ID
+        user = None
+        search = re.search(r"(([0-9]*-[0-9]{1,2}),|gerok38/([a-zA-Z]*\s[a-zA-Z]*))", activity.reference)
+        if search:
+            if activity.reference.startswith('gerok38'):
+                print("Gerok Name: {}".format(search.group(3)))
+                user = User.q.filter_by(name=search.group(3)).first()
+
+            elif True or check_user_id(search.group(2)):
+                uid = search.group(2).split("-")[0]
+                user = User.q.get(uid)
+            if user:
+                matching.update({activity: user})
 
     return matching

--- a/pycroft/lib/finance.py
+++ b/pycroft/lib/finance.py
@@ -719,6 +719,7 @@ def match_activities(BankAccount):
     activity_q = (BankAccountActivity.q
                   .options(joinedload(BankAccountActivity.bank_account))
                   .filter(BankAccountActivity.transaction_id == None))
+
     for activity in activity_q.all():
         # search for user-ID
         user = None

--- a/pycroft/lib/finance.py
+++ b/pycroft/lib/finance.py
@@ -706,7 +706,7 @@ def build_transactions_query(account, search=None, sort_by='valid_on', sort_orde
 
     return query
 
-def match_activities(BankAccount):
+def match_activities():
     """Get a dict of all unmatched transactions and a user they should be matched with
 
     :param BankAccount bank_account: The BankAccount to get the unmatched transactions from

--- a/pycroft/lib/finance.py
+++ b/pycroft/lib/finance.py
@@ -728,7 +728,7 @@ def match_activities(BankAccount):
             if activity.reference.startswith('gerok38'):
                 user = User.q.filter_by(name=search.group(3)).first()
 
-            elif True or check_user_id(search.group(2)):
+            elif check_user_id(search.group(2)):
                 uid = search.group(2).split("-")[0]
                 user = User.q.get(uid)
             if user:

--- a/pycroft/lib/finance.py
+++ b/pycroft/lib/finance.py
@@ -725,7 +725,6 @@ def match_activities(BankAccount):
         search = re.search(r"(([0-9]*-[0-9]{1,2}),|gerok38/([a-zA-Z]*\s[a-zA-Z]*))", activity.reference)
         if search:
             if activity.reference.startswith('gerok38'):
-                print("Gerok Name: {}".format(search.group(3)))
                 user = User.q.filter_by(name=search.group(3)).first()
 
             elif True or check_user_id(search.group(2)):

--- a/pycroft/lib/user.py
+++ b/pycroft/lib/user.py
@@ -82,6 +82,32 @@ def decode_type2_user_id(string):
     return match.groups() if match else None
 
 
+def check_user_id(string):
+    """
+    Check if the given string is a valid user id (type1 or type2).
+    :param string: Type1 or Type2 encoded user ID
+    :returns True if user id was valid, otherwise False
+    :rtype Boolean
+    """
+    idsplit = string.split("-")
+    if len(idsplit) != 2:
+        return False
+    uid = idsplit[0]
+    code = idsplit[1]
+
+    if len(code) == 2:
+        # Type2 code
+        verify = encode_type2_user_id(uid)
+    else:
+        # Type1 code
+        verify = encode_type1_user_id(uid)
+
+    if string == verify:
+        return True
+    else:
+        return False
+
+
 class HostAliasExists(ValueError):
     pass
 

--- a/pycroft/lib/user.py
+++ b/pycroft/lib/user.py
@@ -97,10 +97,10 @@ def check_user_id(string):
 
     if len(code) == 2:
         # Type2 code
-        verify = encode_type2_user_id(uid)
+        verify = encode_type2_user_id(int(uid))
     else:
         # Type1 code
-        verify = encode_type1_user_id(uid)
+        verify = encode_type1_user_id(int(uid))
 
     if string == verify:
         return True

--- a/web/blueprints/finance/__init__.py
+++ b/web/blueprints/finance/__init__.py
@@ -277,11 +277,6 @@ def bank_account_activities_match():
         matching.update(match_activities(acc))
 
     for activity, user in matching.items():
-        print(" ")
-        print(" ")
-        print("activity: ")
-        print(activity)
-        print(" ")
         FieldList.append((str(activity.id), BooleanField('{} ({}€) -> {} ({}, {})'.format(
             activity.reference, activity.amount, user.name, user.id, user.login
         ), default=True)))

--- a/web/blueprints/finance/__init__.py
+++ b/web/blueprints/finance/__init__.py
@@ -277,7 +277,7 @@ def bank_account_activities_match():
     for activity, user in matching.items():
         FieldList.append((str(activity.id), BooleanField('{} ({}€) -> {} ({}, {})'.format(
             activity.reference, activity.amount, user.name, user.id, user.login
-        ), default=True)))
+        ), default=False)))
 
     form = forms.ActivityMatchForm.append_fields(FieldList)()
 
@@ -310,13 +310,13 @@ def bank_account_activities_do_match():
                 debit_account = user.account
                 credit_account = activity.bank_account.account
                 transaction = finance.simple_transaction(
-                    description=form.description.data,
+                    description=activity.reference,
                     debit_account=debit_account,
                     credit_account=credit_account, amount=activity.amount,
                     author=current_user, valid_on=activity.valid_on)
                 activity.split = next(split for split in transaction.splits
                                       if split.account_id == credit_account.id)
-                #session.add(activity)
+                activity.transaction_id = transaction.id
 
                 end_payment_in_default_memberships()
 

--- a/web/blueprints/finance/__init__.py
+++ b/web/blueprints/finance/__init__.py
@@ -270,9 +270,7 @@ def bank_account_activities_match():
         #("Field-Name",BooleanField('Text')),
     ]
 
-    matching = {}
-    for acc in BankAccount.q.all():
-        matching.update(match_activities(acc))
+    matching = match_activities()
 
     for activity, user in matching.items():
         FieldList.append((str(activity.id), BooleanField('{} ({}€) -> {} ({}, {})'.format(
@@ -288,9 +286,7 @@ def bank_account_activities_match():
 def bank_account_activities_do_match():
 
     # Generate form again
-    matching = {}
-    for acc in BankAccount.q.all():
-        matching.update(match_activities(acc))
+    matching = match_activities()
 
     matched = []
     FieldList = []
@@ -316,13 +312,16 @@ def bank_account_activities_do_match():
                     author=current_user, valid_on=activity.valid_on)
                 activity.split = next(split for split in transaction.splits
                                       if split.account_id == credit_account.id)
-                activity.transaction_id = transaction.id
+
+                session.add(activity)
 
                 end_payment_in_default_memberships()
 
-                matched.append( (activity, user) )
+                matched.append((activity, user))
 
+        session.flush()
         session.commit()
+
     return render_template('finance/bank_accounts_matched.html', matched=matched)
 
 @bp.route('/accounts/')

--- a/web/blueprints/finance/forms.py
+++ b/web/blueprints/finance/forms.py
@@ -148,3 +148,10 @@ class TransactionCreateForm(Form):
                       if split_form['amount'].data is not None)
         if balance != 0:
             raise ValidationError(u"Buchung ist nicht ausgeglichen.")
+
+class ActivityMatchForm(Form):
+    @classmethod
+    def append_fields(cls,FieldList):
+        for (name, field) in FieldList:
+            setattr(cls, name, field)
+        return cls

--- a/web/blueprints/finance/forms.py
+++ b/web/blueprints/finance/forms.py
@@ -150,8 +150,4 @@ class TransactionCreateForm(Form):
             raise ValidationError(u"Buchung ist nicht ausgeglichen.")
 
 class ActivityMatchForm(Form):
-    @classmethod
-    def append_fields(cls,FieldList):
-        for (name, field) in FieldList:
-            setattr(cls, name, field)
-        return cls
+    pass

--- a/web/templates/finance/bank_accounts_list.html
+++ b/web/templates/finance/bank_accounts_list.html
@@ -13,6 +13,7 @@
 
     <section>
         <h2 class="page-header">{{ _("Unzugeordnete Kontobewegungen") }}</h2>
+        <a href="{{ url_for('.bank_account_activities_match') }}" class="btn btn-primary">Kontobewegungen matchen</a>
         {{ bank_account_activity_table.render('bank_accounts_activities') }}
     </section>
 {% endblock %}

--- a/web/templates/finance/bank_accounts_match.html
+++ b/web/templates/finance/bank_accounts_match.html
@@ -1,0 +1,33 @@
+{#
+ Copyright (c) 2015 The Pycroft Authors. See the AUTHORS file.
+ This file is part of the Pycroft project and licensed under the terms of
+ the Apache License, Version 2.0. See the LICENSE file for details.
+#}
+{% extends "layout.html" %}
+
+{% set page_title = "Überweisungen matchen" %}
+
+{% block content %}
+
+        <div class="row">
+            <div class="col-md-12">
+                Folgende Nutzer konnten den Überweisungen zugeordnet werden:
+            </div>
+        </div>
+
+        <div class="row">
+            <div class="col-md-12">
+                {{ form.csrf_token }}
+                {% for field in form %}{% if field.type != 'CSRFTokenField' %}
+                    {{ field }} {{ field.label }}<br>
+                {% endif %}{% endfor %}
+            </div>
+        </div>
+
+        <div class="row">
+            <div class="col-md-12" style="margin-top: 20px;">
+                <button type="submit" class="btn btn-primary">Markierte Überweisungen zuordnen</button>
+            </div>
+        </div>
+
+{% endblock %}

--- a/web/templates/finance/bank_accounts_match.html
+++ b/web/templates/finance/bank_accounts_match.html
@@ -1,5 +1,5 @@
 {#
- Copyright (c) 2015 The Pycroft Authors. See the AUTHORS file.
+ Copyright (c) 2018 The Pycroft Authors. See the AUTHORS file.
  This file is part of the Pycroft project and licensed under the terms of
  the Apache License, Version 2.0. See the LICENSE file for details.
 #}

--- a/web/templates/finance/bank_accounts_match.html
+++ b/web/templates/finance/bank_accounts_match.html
@@ -15,6 +15,7 @@
             </div>
         </div>
 
+        <form action="{{ url_for('.bank_account_activities_do_match') }}" method="post">
         <div class="row">
             <div class="col-md-12">
                 {{ form.csrf_token }}
@@ -29,5 +30,6 @@
                 <button type="submit" class="btn btn-primary">Markierte Überweisungen zuordnen</button>
             </div>
         </div>
+        </form>
 
 {% endblock %}

--- a/web/templates/finance/bank_accounts_matched.html
+++ b/web/templates/finance/bank_accounts_matched.html
@@ -1,5 +1,5 @@
 {#
- Copyright (c) 2015 The Pycroft Authors. See the AUTHORS file.
+ Copyright (c) 2018 The Pycroft Authors. See the AUTHORS file.
  This file is part of the Pycroft project and licensed under the terms of
  the Apache License, Version 2.0. See the LICENSE file for details.
 #}

--- a/web/templates/finance/bank_accounts_matched.html
+++ b/web/templates/finance/bank_accounts_matched.html
@@ -1,0 +1,37 @@
+{#
+ Copyright (c) 2015 The Pycroft Authors. See the AUTHORS file.
+ This file is part of the Pycroft project and licensed under the terms of
+ the Apache License, Version 2.0. See the LICENSE file for details.
+#}
+{% extends "layout.html" %}
+
+{% set page_title = "Überweisungen matchen" %}
+
+{% block content %}
+
+        <div class="row">
+            <div class="col-md-12">
+                Folgende Überweisungen wurden zugeordnet:<br><br>
+            </div>
+        </div>
+
+        <div class="row">
+            <div class="col-md-6">
+                <b>Überweisung</b>
+            </div>
+            <div class="col-md-6">
+                <b>Nutzer</b>
+            </div>
+        </div>
+        {% for match in matched %}
+        <div class="row">
+            <div class="col-md-6">
+                {{ match[0].reference }} ({{ match[0].amount }}€)
+            </div>
+            <div class="col-md-6">
+                <a href="{{ url_for('user.user_show', user_id=match[1].id) }}">{{ match[1].name }}</a>
+            </div>
+        </div>
+        {% endfor %}
+
+{% endblock %}


### PR DESCRIPTION
This is a simple and quick implementation to match unassigned bank-account activities.
The references of the unmatched BankAccountActivities are matched against:
- User-ID type 1
- User-ID type 2
- `gerok38/Name`

So most of the activities should be matched to a user.