### PR TITLE
Fix RuntimeError on empty Radius-Logs

### DIFF
--- a/hades_logs/parsing.py
+++ b/hades_logs/parsing.py
@@ -90,7 +90,11 @@ def reduce_to_first_occurrence(iterable, comparator=_eq):
         previous element.
     """
     iterator = iter(iterable)
-    previous = next(iterator)
+    try:
+        previous = next(iterator)
+    except StopIteration:
+        return
+
     yield previous
 
     for element in iterator:


### PR DESCRIPTION
Log for Users in dormitories RBS and Gutz show HTTP Error 500 because the Switches in these dormitories are not able to do radius auth. If there Is an empty answer from Hades, it causes an HTTP 500.