### PR TITLE
Error handling for finance importer

### DIFF
--- a/pycroft/model/alembic/versions/8ff6f90b98fa_add_table_for_mt940_parsing_errors.py
+++ b/pycroft/model/alembic/versions/8ff6f90b98fa_add_table_for_mt940_parsing_errors.py
@@ -1,0 +1,35 @@
+"""add table for mt940 parsing errors
+
+Revision ID: 8ff6f90b98fa
+Revises: 08fa5b3cc555
+Create Date: 2018-12-20 18:34:05.289624
+
+"""
+from alembic import op
+import sqlalchemy as sa
+import pycroft
+from sqlalchemy.dialects import postgresql
+
+# revision identifiers, used by Alembic.
+revision = '8ff6f90b98fa'
+down_revision = '08fa5b3cc555'
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.create_table('mt940_error',
+    sa.Column('id', sa.Integer(), nullable=False),
+    sa.Column('mt940', sa.Text(), nullable=False),
+    sa.Column('exception', sa.Text(), nullable=False),
+    sa.Column('author_id', sa.Integer(), nullable=False),
+    sa.Column('imported_at', pycroft.model.types.DateTimeTz(), server_default=sa.text('CURRENT_TIMESTAMP'), nullable=False),
+    sa.Column('bank_account_id', sa.Integer(), nullable=False),
+    sa.ForeignKeyConstraint(['author_id'], ['user.id'], ),
+    sa.ForeignKeyConstraint(['bank_account_id'], ['bank_account.id'], ),
+    sa.PrimaryKeyConstraint('id')
+    )
+
+
+def downgrade():
+    op.drop_table('mt940_error')

--- a/pycroft/model/finance.py
+++ b/pycroft/model/finance.py
@@ -325,6 +325,25 @@ class BankAccountActivity(IntegerIdModel):
     )
 
 
+class MT940Error(IntegerIdModel):
+    mt940 = Column(Text(), nullable=False)
+    exception = Column(Text(), nullable=False)
+    author = relationship("User")
+    author_id = Column(Integer, ForeignKey("user.id"), nullable=False)
+    imported_at = Column(DateTimeTz, nullable=False,
+                       server_default=func.current_timestamp(),
+                       onupdate=func.current_timestamp())
+    bank_account = relationship(BankAccount, backref=backref("mt940_errors"))
+    bank_account_id = Column(Integer, ForeignKey(BankAccount.id),
+                             nullable=False)
+
+    def __init__(self, mt940, exception, author, bank_account):
+        self.mt940 = mt940
+        self.exception = exception
+        self.author = author
+        self.bank_account = bank_account
+
+
 manager.add_constraint(
     BankAccount.__table__,
     CheckConstraint(

--- a/requirements.txt
+++ b/requirements.txt
@@ -27,7 +27,7 @@ alembic~=0.9.6
 simplejson~=3.11.1
 #usersheet generation
 reportlab~=3.4.0
-fints~=0.2.1
+fints~=2.0.0
 uwsgi~=2.0.14
 GitPython~=2.1.7
 manuf~=1.0.0

--- a/web/blueprints/finance/forms.py
+++ b/web/blueprints/finance/forms.py
@@ -7,6 +7,7 @@ from flask_wtf import FlaskForm as Form
 from wtforms import Form as WTForm, ValidationError
 from wtforms.validators import DataRequired, NumberRange, Optional, \
     InputRequired
+from wtforms.widgets import TextArea
 
 from web.form.fields.core import (
     TextField, IntegerField, HiddenField, FileField, SelectField, FormField,
@@ -169,3 +170,7 @@ class HandlePaymentsInDefaultForm(Form):
     terminated_member_memberships = QuerySelectMultipleField(u"Beendete Mitgliedschaften/Auszüge",
                                                              get_label=get_user_name_with_id,
                                                              render_kw={'size': 20})
+
+class FixMT940Form(Form):
+    mt940 = StringField(u'MT940', widget=TextArea())
+    do_import = BooleanField(u"Import durchführen", default=False)

--- a/web/blueprints/finance/tables.py
+++ b/web/blueprints/finance/tables.py
@@ -211,3 +211,14 @@ class TransactionTable(BootstrapTable):
         ], table_args = {
             'data-row-style': 'table.financeRowFormatter',
         }, **kw)
+
+
+class ImportErrorTable(BootstrapTable):
+    """A table for displaying buggy mt940 imports"""
+    def __init__(self, *a, create_account=False, **kw):
+        self.create_account = create_account
+        super().__init__(*a, columns=[
+            Column(name='name', title='Bankkonto'),
+            Column(name='imported_at', title='Importiert am'),
+            Column(name='fix', title='Importieren', formatter='table.btnFormatter'),
+        ], **kw)

--- a/web/blueprints/helpers/fints.py
+++ b/web/blueprints/helpers/fints.py
@@ -16,10 +16,12 @@ class FinTS3Client(FinTS3PinTanClient):
         Fetches the list of transactions of a bank account in a certain timeframe.
         MT940-Errors are catched and the statements containing them returned as
         a seperate list.
+
         :param account: SEPA
         :param start_date: First day to fetch
         :param end_date: Last day to fetch
-        :return: A list of mt940.models.Transaction objects
+        :return: A tuple with list of mt940.models.Transaction objects and another
+        list with tuples of mt940-data and error messages.
         """
 
         with self._get_dialog() as dialog:

--- a/web/blueprints/helpers/fints.py
+++ b/web/blueprints/helpers/fints.py
@@ -1,0 +1,59 @@
+import datetime
+import logging
+from fints.client import FinTS3PinTanClient
+from fints.models import SEPAAccount
+from fints.segments.statement import HKKAZ5, HKKAZ6, HKKAZ7
+from fints.utils import mt940_to_array
+
+logger = logging.getLogger(__name__)
+
+class FinTS3Client(FinTS3PinTanClient):
+
+    def get_filtered_transactions(self, account: SEPAAccount,
+                         start_date: datetime.date = None,
+                         end_date: datetime.date = None):
+        """
+        Fetches the list of transactions of a bank account in a certain timeframe.
+        MT940-Errors are catched and the statements containing them returned as
+        a seperate list.
+        :param account: SEPA
+        :param start_date: First day to fetch
+        :param end_date: Last day to fetch
+        :return: A list of mt940.models.Transaction objects
+        """
+
+        with self._get_dialog() as dialog:
+            hkkaz = self._find_highest_supported_command(HKKAZ5, HKKAZ6, HKKAZ7)
+
+            logger.info(
+                'Start fetching from {} to {}'.format(start_date, end_date))
+            responses = self._fetch_with_touchdowns(
+                dialog,
+                lambda touchdown: hkkaz(
+                    account=hkkaz._fields['account'].type.from_sepa_account(
+                        account),
+                    all_accounts=False,
+                    date_start=start_date,
+                    date_end=end_date,
+                    touchdown_point=touchdown,
+                ),
+                'HIKAZ'
+            )
+            logger.info('Fetching done.')
+
+        statement = []
+        with_error = []
+        for seg in responses:
+            # Note: MT940 messages are encoded in the S.W.I.F.T character set,
+            # which is a subset of ISO 8859. There are no character in it that
+            # differ between ISO 8859 variants, so we'll arbitrarily chose 8859-1.
+            try:
+                statement += mt940_to_array(
+                    seg.statement_booked.decode('iso-8859-1'))
+            except Exception as e:
+                with_error.append((seg.statement_booked.decode('iso-8859-1'), str(e)))
+
+        logger.debug('Statement: {}'.format(statement))
+
+
+        return statement, with_error

--- a/web/templates/finance/_import_preview.html
+++ b/web/templates/finance/_import_preview.html
@@ -1,0 +1,42 @@
+{% if transactions %}
+    Folgende Bewegungen werden importiert:
+    <table class="table table-striped">
+    <tr>
+        <th>Betrag</th>
+        <th>Verwendungszweck</th>
+        <th>IBAN</th>
+        <th>Name</th>
+        <th>Datum</th>
+    </tr>
+    {% for transaction in transactions %}
+        <tr>
+            <td>{{ transaction.amount }}</td>
+            <td>{{ transaction.reference }}</td>
+            <td>{{ transaction.other_account_number }}</td>
+            <td>{{ transaction.other_name }}</td>
+            <td>{{ transaction.valid_on }}</td>
+        </tr>
+    {% endfor %}
+    </table>
+{% endif %}
+{% if old_transactions %}
+    Folgende Bewegungen wurden bereits früher importiert:
+    <table class="table table-striped">
+    <tr>
+        <th>Betrag</th>
+        <th>Verwendungszweck</th>
+        <th>IBAN</th>
+        <th>Name</th>
+        <th>Datum</th>
+    </tr>
+    {% for transaction in old_transactions %}
+        <tr>
+            <td>{{ transaction.amount }}</td>
+            <td>{{ transaction.reference }}</td>
+            <td>{{ transaction.other_account_number }}</td>
+            <td>{{ transaction.other_name }}</td>
+            <td>{{ transaction.valid_on }}</td>
+        </tr>
+    {% endfor %}
+    </table>
+{% endif %}

--- a/web/templates/finance/bank_accounts_error_fix.html
+++ b/web/templates/finance/bank_accounts_error_fix.html
@@ -1,0 +1,41 @@
+{#
+ Copyright (c) 2015 The Pycroft Authors. See the AUTHORS file.
+ This file is part of the Pycroft project and licensed under the terms of
+ the Apache License, Version 2.0. See the LICENSE file for details.
+#}
+{% extends "layout.html" %}
+
+{% set page_title = "MT940 Korrektur" %}
+{% block content %}
+  <section>
+    <b>Beim Import aufgetretener Fehler:</b><br>
+    <span style="font-family: monospace;">{{ exception }}</span><br>
+    <br>
+    {% if new_exception %}
+      <b>Nach Korrektur aufgetretener Fehler:</b><br>
+      <span style="font-family: monospace;">{{ new_exception }}</span><br>
+      <br>
+    {% endif %}
+
+    <form method="POST" action="{{ url_for('.fix_import_error', error_id=error_id) }}" role="form">
+        {{ form.csrf_token() }}
+        <div class="row">
+            <div class="col-xs-12">
+              {{ form.mt940(class="form-control",rows="20") }}
+            </div>
+        </div>
+        <br>
+        <div class="row">
+          <div class="col-xs-6">
+            {{ form.do_import() }}
+          </div>
+         <div class="col-xs-6">
+            <input type="submit" class="btn btn-primary" value="übernehmen">
+         </div>
+        </div>
+
+    </form>
+  </section>
+
+  {% include "finance/_import_preview.html" with context %}
+{% endblock %}

--- a/web/templates/finance/bank_accounts_import.html
+++ b/web/templates/finance/bank_accounts_import.html
@@ -11,46 +11,5 @@
 {% block single_row_content %}
     {{ forms.simple_form(form, '', url_for('.bank_accounts_list'), autocomplete="on") }}
 
-    {% if transactions %}
-        Folgende Bewegungen werden importiert:
-        <table class="table table-striped">
-        <tr>
-            <th>Betrag</th>
-            <th>Verwendungszweck</th>
-            <th>IBAN</th>
-            <th>Name</th>
-            <th>Datum</th>
-        </tr>
-        {% for transaction in transactions %}
-            <tr>
-                <td>{{ transaction.amount }}</td>
-                <td>{{ transaction.reference }}</td>
-                <td>{{ transaction.other_account_number }}</td>
-                <td>{{ transaction.other_name }}</td>
-                <td>{{ transaction.valid_on }}</td>
-            </tr>
-        {% endfor %}
-        </table>
-    {% endif %}
-    {% if old_transactions %}
-        Folgende Bewegungen wurden bereits früher importiert:
-        <table class="table table-striped">
-        <tr>
-            <th>Betrag</th>
-            <th>Verwendungszweck</th>
-            <th>IBAN</th>
-            <th>Name</th>
-            <th>Datum</th>
-        </tr>
-        {% for transaction in old_transactions %}
-            <tr>
-                <td>{{ transaction.amount }}</td>
-                <td>{{ transaction.reference }}</td>
-                <td>{{ transaction.other_account_number }}</td>
-                <td>{{ transaction.other_name }}</td>
-                <td>{{ transaction.valid_on }}</td>
-            </tr>
-        {% endfor %}
-        </table>
-    {% endif %}
+    {% include "finance/_import_preview.html" with context %}
 {% endblock %}

--- a/web/templates/finance/bank_accounts_import.html
+++ b/web/templates/finance/bank_accounts_import.html
@@ -53,5 +53,4 @@
         {% endfor %}
         </table>
     {% endif %}
-
 {% endblock %}

--- a/web/templates/finance/bank_accounts_import_errors.html
+++ b/web/templates/finance/bank_accounts_import_errors.html
@@ -1,0 +1,12 @@
+{#
+ Copyright (c) 2015 The Pycroft Authors. See the AUTHORS file.
+ This file is part of the Pycroft project and licensed under the terms of
+ the Apache License, Version 2.0. See the LICENSE file for details.
+#}
+{% extends "layout.html" %}
+
+{% block content %}
+    <section id="tbl_bank_accounts">
+        {{ error_table.render('bank_accounts') }}
+    </section>
+{% endblock %}


### PR DESCRIPTION
This PR adds:

- switch to python-fints version 2.0.0
- catch errors which occur during finance import and save them while importing valid statements
- ability to review and fix mt940 of errored statements

**In detail:**
If a part of the MT940 received from our bank is not valid, this part will be skipped and saved with the exception. After importing all other statements the treasurer has the ability to review the MT940, fix it and execute the importer again.
The UI for fixing the MT940 could be found at "Finanzen > Fehlerhafter Bankimport".