### PR TITLE
Fix hadeslog tests

### DIFF
--- a/docker-compose.base.yml
+++ b/docker-compose.base.yml
@@ -56,11 +56,3 @@ services:
     environment:
       - RABBITMQ_DEFAULT_USER=celery
       - RABBITMQ_DEFAULT_PASS=celery
-  dummy-worker:
-    extends:
-      service: dev
-    command: ["python", "helpers/dummy_celery_worker.py", "worker"]
-    environment:
-      - TEST_HADES_BROKER_URI=amqp://celery:celery@mq:5672/
-      - TEST_HADES_RESULT_BACKEND_URI=rpc://celery:celery@mq:5672/
-

--- a/docker-compose.test.yml
+++ b/docker-compose.test.yml
@@ -58,10 +58,19 @@ services:
           - mq
     tmpfs:
       - /var/lib/rabbitmq
+  # a dummy worker mocking hades for testing the client
   test-dummy-worker:
     extends:
       file: docker-compose.base.yml
-      service: dummy-worker
+      service: dev
+    command: "dummy-worker worker --loglevel=debug"
+    environment:
+      - TEST_HADES_BROKER_URI=amqp://celery:celery@mq:5672/
+      - TEST_HADES_RESULT_BACKEND_URI=rpc://celery:celery@mq:5672/
+    depends_on:
+      - test-mq
+    networks:
+      - test
 
 networks:
   test:

--- a/docker/dev/container/commands/dummy-worker
+++ b/docker/dev/container/commands/dummy-worker
@@ -1,0 +1,17 @@
+#!/bin/bash
+
+set -euo pipefail
+
+readonly USAGE=("[args]")
+
+readonly DESCRIPTION=(
+	"Run dummy celery worker. Optional arguments are passed to the Celery worker
+	executable"
+)
+
+run() {
+	cd /opt/pycroft/app
+	exec -a python /opt/pycroft/venv/bin/python helpers/dummy_celery_worker.py "$@"
+}
+
+[[ "$0" == "$BASH_SOURCE" ]] && run "$@" || :

--- a/docker/dev/container/hooks/init/90_fix_celery
+++ b/docker/dev/container/hooks/init/90_fix_celery
@@ -1,0 +1,26 @@
+#!/bin/bash
+
+set -euo pipefail
+
+# Fix Celery on Python 3.7
+# Adapted from https://github.com/ddliu/dockerfiles/blob/master/special/nc/ns/fix.sh
+# https://github.com/celery/celery/issues/4500
+TARGET=/opt/pycroft/venv/lib/python3.7/site-packages/
+
+cd "$TARGET"/celery/backends
+if [ -e async.py ]
+then
+    mv async.py asynchronous.py
+    sed -i 's/async/asynchronous/g' redis.py
+    sed -i 's/async/asynchronous/g' rpc.py
+
+    find "$TARGET" -type f -iname "*.py" -exec sed -i 's/kombu\.async\b/kombu.asynchronous/g' {} +
+fi
+
+cd "$TARGET"/kombu
+if [ -e async ]
+then
+    mv async asynchronous
+
+    find . -type f -iname "*.py" -exec sed -i 's/\basync\b/asynchronous/g' {} +
+fi

--- a/docker/dev/container/hooks/init/90_fix_celery
+++ b/docker/dev/container/hooks/init/90_fix_celery
@@ -7,19 +7,13 @@ set -euo pipefail
 # https://github.com/celery/celery/issues/4500
 TARGET=/opt/pycroft/venv/lib/python3.7/site-packages/
 
-cd "$TARGET"/celery/backends
-if [ -e async.py ]
-then
-    mv async.py asynchronous.py
-    sed -i 's/async/asynchronous/g' redis.py
-    sed -i 's/async/asynchronous/g' rpc.py
-
-    find "$TARGET" -type f -iname "*.py" -exec sed -i 's/kombu\.async\b/kombu.asynchronous/g' {} +
-fi
+echo "Patching celery to ensure Python 3.7 compatibility"
+find "$TARGET" -type f -iname "*.py" -exec sed -i 's/kombu\.async\b/kombu.asynchronous/g' {} +
 
 cd "$TARGET"/kombu
 if [ -e async ]
 then
+    echo "Patching kombu to ensure Python 3.7 compatibility"
     mv async asynchronous
 
     find . -type f -iname "*.py" -exec sed -i 's/\basync\b/asynchronous/g' {} +

--- a/tests/hades_logs/__init__.py
+++ b/tests/hades_logs/__init__.py
@@ -18,6 +18,7 @@ class DummyHadesWorkerBase(TestCase):
             'HADES_CELERY_APP_NAME': 'dummy_tasks',
             'HADES_BROKER_URI': self.BROKER_URL,
             'HADES_RESULT_BACKEND_URI': self.BACKEND_URL,
+            'HADES_ROUTING_KEY': None,
         }
 
 

--- a/tests/hades_logs/test_hades_logs_integration.py
+++ b/tests/hades_logs/test_hades_logs_integration.py
@@ -1,13 +1,8 @@
-from unittest import skip
-
 from hades_logs import HadesLogs, HadesTimeout
 from hades_logs.parsing import RadiusLogEntry
 from . import SimpleFlaskWithHadesLogsBase
 
-reason = "Hades logs worker does not run on 3.7 for compat reasons"
 
-
-@skip(reason)
 class ConfiguredHadesLogs(SimpleFlaskWithHadesLogsBase):
     def test_nonexistent_port_has_no_logs(self):
         logs = self.fetch_logs(nasipaddress='', nasportid='')
@@ -42,7 +37,6 @@ class ConfiguredHadesLogs(SimpleFlaskWithHadesLogsBase):
             self.assertEqual(tasks, [])
 
 
-@skip(reason)
 class SpecificLogsTestCase(SimpleFlaskWithHadesLogsBase):
     def setUp(self):
         super().setUp()


### PR DESCRIPTION
Mostly reviving the celery dummy worker in our new docker setup. Additionally, I added a nasty workaround script that patches celery and its dependency kombu, to make them compatible with Python 3.7 (https://github.com/celery/celery/issues/4500). An official fix is announced for version 4.3, originally scheduled for November 30, 2018, but now rescheduled for January 31th, 2019. If we update to celery 4.3 we also have to upgrade hades to celery 4, because celery 4 is not backward compatible to celery 3.