### PR TITLE
Move name and birth date out of link so they are easier to copy

### DIFF
--- a/web/templates/user/_user_show_basedata.html
+++ b/web/templates/user/_user_show_basedata.html
@@ -18,7 +18,7 @@
 
             {% call info_row("Name") %}
                 {% if current_user is privileged_for('user_change') %}
-                <a href="{{ url_for(".edit_user", user_id=user.id) }}">{{ user.name }} <span class="glyphicon glyphicon-edit"></span></a>
+                {{ user.name }} <a href="{{ url_for(".edit_user", user_id=user.id) }}"><span class="glyphicon glyphicon-edit"></span></a>
                 {% else %}
                 {{ user.name }}
                 {% endif %}
@@ -50,7 +50,7 @@
 
             {% call info_row("Geburtsdatum") %}
                 {% if current_user is privileged_for('user_change') %}
-                <a href="{{ url_for(".edit_user", user_id=user.id) }}">{{ user.birthdate|date}} <span class="glyphicon glyphicon-edit"></span></a>
+                {{ user.birthdate|date}}<a href="{{ url_for(".edit_user", user_id=user.id) }}"><span class="glyphicon glyphicon-edit"></span></a>
                 {% else %}
                 {{ user.birthdate|date }}
                 {% endif %}


### PR DESCRIPTION
In Chromium it is hard to mark the name and birth date because it will try to move the link itself. This makes that easier. Also there is no reason for the link to contain the complete text.