### PR TITLE
manual mt940 bank import

### DIFF
--- a/web/blueprints/finance/__init__.py
+++ b/web/blueprints/finance/__init__.py
@@ -240,10 +240,10 @@ def bank_accounts_import():
 @access.require('finance_change')
 def bank_accounts_import_manual():
     form = BankAccountActivitiesImportManualForm()
-    form.account.choices = [(acc.id, acc.name) for acc in BankAccount.q.all()]
+    form.account.query = BankAccount.q.all()
 
     if form.validate_on_submit():
-        bank_account = BankAccount.q.get(form.account.data)
+        bank_account = form.account.data
 
         if form.file.data:
             mt940 = form.file.data.read().decode()

--- a/web/blueprints/finance/forms.py
+++ b/web/blueprints/finance/forms.py
@@ -11,7 +11,7 @@ from wtforms.validators import DataRequired, NumberRange, Optional, \
 from web.form.fields.core import (
     TextField, IntegerField, HiddenField, FileField, SelectField, FormField,
     FieldList, StringField, DateField, MoneyField, PasswordField, DecimalField,
-    BooleanField, SelectMultipleField, QuerySelectMultipleField, TextAreaField)
+    BooleanField, SelectMultipleField, QuerySelectMultipleField, TextAreaField, QuerySelectField)
 from web.form.fields.custom import TypeaheadField, static, disabled
 from pycroft.helpers.i18n import gettext
 from pycroft.model.finance import BankAccount
@@ -117,8 +117,8 @@ class BankAccountActivitiesImportForm(Form):
 
 
 class BankAccountActivitiesImportManualForm(Form):
-    account = SelectField(u"Bankkonto", coerce=int)
-    file = FileField(u'MT940 Datei')
+    account = QuerySelectField('Bankkonto', get_label="name")
+    file = FileField('MT940 Datei')
 
 
 class AccountCreateForm(Form):

--- a/web/blueprints/finance/forms.py
+++ b/web/blueprints/finance/forms.py
@@ -116,6 +116,11 @@ class BankAccountActivitiesImportForm(Form):
     do_import = BooleanField(u"Import durchführen", default=False)
 
 
+class BankAccountActivitiesImportManualForm(Form):
+    account = SelectField(u"Bankkonto", coerce=int)
+    file = FileField(u'MT940 Datei')
+
+
 class AccountCreateForm(Form):
     name = TextField(u"Name", validators=[DataRequired()])
     type = SelectField(

--- a/web/templates/finance/bank_accounts_import.html
+++ b/web/templates/finance/bank_accounts_import.html
@@ -23,6 +23,11 @@
                 <span class="glyphicon glyphicon-remove"></span>
                 Fehlerhafter Import
             </a>
+
+            <a class="btn btn-primary" href="{{ url_for('.bank_accounts_import_manual') }}">
+                <span class="glyphicon glyphicon-download"></span>
+                Manueller Datenimport
+            </a>
         </div>
     </div>
 {% endblock %}

--- a/web/templates/finance/bank_accounts_import_manual.html
+++ b/web/templates/finance/bank_accounts_import_manual.html
@@ -1,0 +1,21 @@
+{#
+ Copyright (c) 2019 The Pycroft Authors. See the AUTHORS file.
+ This file is part of the Pycroft project and licensed under the terms of
+ the Apache License, Version 2.0. See the LICENSE file for details.
+#}
+{% extends "layout.html" %}
+{% import "macros/forms.html" as forms %}
+{% set page_title = "Bankkontobewegungen manuell importieren" %}
+
+{% import "macros/forms.html" as forms %}
+{% block single_row_content %}
+    <div class="row">
+        <div class="col-xs-12">
+            Zum manuellen Import die Umsätze im MT940-Format bei der Bank abrufen und hier hochladen.
+        </div>
+    </div>
+
+    <br>
+
+    {{ forms.upload_form(form, '', url_for('.bank_accounts_import_manual')) }}
+{% endblock %}


### PR DESCRIPTION
This PR adds the possibility to import transactions without the use of FinTS.
The transactions need to be downloaded from the online banking as a MT940 file which will be uploaded to Pycroft. The MT940 is saved like an unsuccessfull FinTS import. So, after uploading the file, the transactions can be reviewed and imported.