### PR TITLE
Membership fee per dorm

### DIFF
--- a/pycroft/helpers/interval.py
+++ b/pycroft/helpers/interval.py
@@ -749,7 +749,7 @@ def _intersect(left, right):
 
 
 class IntervalModel:
-    begins_at = Column(DateTimeTz, nullable=True, index=True, server_default=func.current_timestamp())
+    begins_at = Column(DateTimeTz, nullable=False, index=True, server_default=func.current_timestamp())
     ends_at = Column(DateTimeTz, nullable=True, index=True)
 
     __table_args = (

--- a/pycroft/helpers/interval.py
+++ b/pycroft/helpers/interval.py
@@ -752,10 +752,9 @@ class IntervalModel:
     begins_at = Column(DateTimeTz, nullable=False, index=True, server_default=func.current_timestamp())
     ends_at = Column(DateTimeTz, nullable=True, index=True)
 
-    __table_args = (
-        CheckConstraint("begins_at IS NULL OR "
-                        "ends_at IS NULL OR "
-                        "begins_at <= moved_out")
+    __table_args__ = (
+        CheckConstraint("ends_at IS NULL OR "
+                        "begins_at <= ends_at"),
     )
 
     @hybrid_method

--- a/pycroft/helpers/interval.py
+++ b/pycroft/helpers/interval.py
@@ -753,8 +753,7 @@ class IntervalModel:
     ends_at = Column(DateTimeTz, nullable=True, index=True)
 
     __table_args__ = (
-        CheckConstraint("ends_at IS NULL OR "
-                        "begins_at <= ends_at"),
+        CheckConstraint("ends_at IS NULL OR begins_at <= ends_at"),
     )
 
     @hybrid_method

--- a/pycroft/helpers/interval.py
+++ b/pycroft/helpers/interval.py
@@ -800,8 +800,8 @@ class IntervalModel:
 
     @validates('begins_at')
     def validate_begins_at(self, _, value):
-        if value is None:
-            return value
+        assert value is not None, "begins_at cannot be None"
+
         if self.ends_at is not None:
             assert value <= self.ends_at,\
                 "begins_at must be before ends_at"

--- a/pycroft/lib/finance.py
+++ b/pycroft/lib/finance.py
@@ -665,8 +665,7 @@ def get_users_with_payment_in_default():
         try:
             fee_date = ts_now - timedelta(days=in_default_days)
 
-            # datetime not working as datetime type
-            fee = get_membership_fee_for_date(str(fee_date))
+            fee = get_membership_fee_for_date(fee_date)
         except NoResultFound:
             fee = get_last_applied_membership_fee()
 

--- a/pycroft/lib/finance.py
+++ b/pycroft/lib/finance.py
@@ -634,9 +634,7 @@ def get_transaction_type(transaction):
 
 
 @with_transaction
-def end_payment_in_default_memberships():
-    processor = User.q.get(0)
-
+def end_payment_in_default_memberships(processor):
     users = User.q.join(User.current_properties) \
                 .filter(CurrentProperty.property_name == 'payment_in_default') \
                 .join(Account).filter(Account.balance <= 0).all()

--- a/pycroft/lib/finance.py
+++ b/pycroft/lib/finance.py
@@ -644,7 +644,7 @@ def end_payment_in_default_memberships():
     for user in users:
         if user.member_of(config.payment_in_default_group):
             remove_member_of(user, config.payment_in_default_group, processor,
-                             closedopen(session.utcnow(), None))
+                             closedopen(session.utcnow() - timedelta(seconds=1), None))
 
     return users
 
@@ -711,7 +711,7 @@ def take_actions_for_payment_in_default_users(users_pid_membership,
 
     for user in users_membership_terminated:
         if user.member_of(config.member_group):
-            move_out(user, "Zahlungsrückstand", processor, ts_now, True)
+            move_out(user, "Zahlungsrückstand", processor, ts_now - timedelta(seconds=1), True)
 
             log_user_event("Mitgliedschaftsende wegen Zahlungsrückstand.",
                            processor, user)

--- a/pycroft/lib/user.py
+++ b/pycroft/lib/user.py
@@ -302,6 +302,9 @@ def move_in(user, building_id, level, room_number, mac, processor, birthdate=Non
                                               'begin_membership': begin_membership},
                                   processor=processor)
     else:
+        if user.room is not None:
+            raise ValueError("user is already living in a room.")
+
         room = get_room(building_id, level, room_number)
 
         if birthdate:

--- a/pycroft/model/alembic/versions/c11d3d8b16ae_building_fee_account.py
+++ b/pycroft/model/alembic/versions/c11d3d8b16ae_building_fee_account.py
@@ -67,7 +67,10 @@ def upgrade():
 
                     IF new.room_id IS NOT NULL THEN
                         /* User moved to a new room. history entry must be created */
-                        INSERT INTO "room_history_entry" (user_id, room_id) VALUES(new.id, new.room_id);
+                        INSERT INTO "room_history_entry" (user_id, room_id, begins_at)
+                            /* We must add one second so that the user doesn't have two entries
+                               for the same timestamp */
+                            VALUES(new.id, new.room_id, CURRENT_TIMESTAMP + INTERVAL '1' second);
                     END IF;
                 END IF;
                 RETURN NULL;

--- a/pycroft/model/alembic/versions/c11d3d8b16ae_building_fee_account.py
+++ b/pycroft/model/alembic/versions/c11d3d8b16ae_building_fee_account.py
@@ -9,6 +9,7 @@ import sqlalchemy as sa
 from alembic import op
 
 # revision identifiers, used by Alembic.
+from pycroft.model.facilities import Building
 from pycroft.model.types import DateTimeTz
 from pycroft.model.user import User, RoomHistoryEntry
 
@@ -22,6 +23,10 @@ def upgrade():
     op.add_column('building', sa.Column('fee_account_id', sa.Integer(), nullable=True))
     op.create_foreign_key('building_fee_account_id_fkey', 'building', 'account',
                           ['fee_account_id'], ['id'])
+
+    op.execute(sa.update(Building).values(fee_account_id=19))
+
+    op.alter_column('building', 'fee_account_id', nullable=False)
 
     # Make beginning of a membership not nullable as it makes no sense
     op.alter_column('membership', 'begins_at', nullable=False)

--- a/pycroft/model/alembic/versions/c11d3d8b16ae_building_fee_account.py
+++ b/pycroft/model/alembic/versions/c11d3d8b16ae_building_fee_account.py
@@ -96,5 +96,7 @@ def downgrade():
     op.execute('drop trigger if exists "user_room_change_update_history_trigger" on "user"')
     op.execute('drop function if exists user_room_change_update_history();')
 
+    op.alter_column('membership', 'begins_at', nullable=True)
     op.drop_constraint('membership_check', 'membership', type_='check')
+
     op.drop_table("room_history_entry")

--- a/pycroft/model/alembic/versions/c11d3d8b16ae_building_fee_account.py
+++ b/pycroft/model/alembic/versions/c11d3d8b16ae_building_fee_account.py
@@ -1,0 +1,84 @@
+"""building_fee_account
+
+Revision ID: c11d3d8b16ae
+Revises: 37b57e0baa3a
+Create Date: 2020-02-26 23:05:46.376751
+
+"""
+import sqlalchemy as sa
+from alembic import op
+
+# revision identifiers, used by Alembic.
+from pycroft.model.types import DateTimeTz
+from pycroft.model.user import User, RoomHistoryEntry
+
+revision = 'c11d3d8b16ae'
+down_revision = '37b57e0baa3a'
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.add_column('building', sa.Column('fee_account_id', sa.Integer(), nullable=True))
+    op.create_foreign_key('building_fee_account_id_fkey', 'building', 'account',
+                          ['fee_account_id'], ['id'])
+
+    op.create_table('room_history_entry',
+                    sa.Column('id', sa.Integer(), nullable=False),
+                    sa.Column('user_id', sa.Integer(), nullable=False),
+                    sa.Column('room_id', sa.Integer(), nullable=False),
+                    sa.Column('begins_at', DateTimeTz, nullable=True,
+                              server_default=sa.func.current_timestamp()),
+                    sa.Column('ends_at', DateTimeTz, nullable=True),
+
+                    sa.ForeignKeyConstraint(['user_id'], ['user.id'], ),
+                    sa.ForeignKeyConstraint(['room_id'], ['room.id'], ),
+                    sa.PrimaryKeyConstraint('id')
+                    )
+
+    op.execute('''
+            create or replace function user_room_change_update_history() returns trigger
+                strict
+                language plpgsql
+            as $$
+            BEGIN
+                IF old.room_id IS DISTINCT FROM new.room_id THEN
+                    IF old IS NOT NULL AND old.room_id IS NOT NULL THEN
+                        /* User was living in a room before, history entry must be ended */
+                        UPDATE "room_history_entry" SET ends_at = CURRENT_TIMESTAMP
+                            WHERE user_id = new.id AND ends_at IS NULL;
+                    END IF;
+
+                    IF new.room_id IS NOT NULL THEN
+                        /* User moved to a new room. history entry must be created */
+                        INSERT INTO "room_history_entry" (user_id, room_id) VALUES(new.id, new.room_id);
+                    END IF;
+                END IF;
+                RETURN NULL;
+            END;
+            $$;
+        ''')
+
+    op.execute('''
+        create trigger user_room_change_update_history_trigger
+        after update
+        on "user"
+        for each row
+        execute procedure user_room_change_update_history();
+    ''')
+
+    op.execute(
+        RoomHistoryEntry.__table__.insert().from_select(
+            [RoomHistoryEntry.user_id, RoomHistoryEntry.room_id, RoomHistoryEntry.begins_at],
+            sa.select([User.id, User.room_id, User.registered_at]).select_from(User).where(User.room_id.isnot(None)))
+    )
+
+
+def downgrade():
+    op.drop_constraint('building_fee_account_id_fkey', 'building', type_='foreignkey')
+    op.drop_column('building', 'fee_account_id')
+
+    op.execute('drop trigger if exists "user_room_change_update_history_trigger" on "user"')
+    op.execute('drop function if exists user_room_change_update_history();')
+
+    op.drop_table("room_history_entry")

--- a/pycroft/model/alembic/versions/c11d3d8b16ae_building_fee_account.py
+++ b/pycroft/model/alembic/versions/c11d3d8b16ae_building_fee_account.py
@@ -1,7 +1,7 @@
 """building_fee_account
 
 Revision ID: c11d3d8b16ae
-Revises: 37b57e0baa3a
+Revises: 3ec1d29bfd10
 Create Date: 2020-02-26 23:05:46.376751
 
 """
@@ -14,7 +14,7 @@ from pycroft.model.types import DateTimeTz
 from pycroft.model.user import User, RoomHistoryEntry
 
 revision = 'c11d3d8b16ae'
-down_revision = '37b57e0baa3a'
+down_revision = '3ec1d29bfd10'
 branch_labels = None
 depends_on = None
 
@@ -134,6 +134,10 @@ def upgrade():
             sa.select([User.id, User.room_id, User.registered_at]).select_from(User).where(User.room_id.isnot(None)))
     )
 
+    # Update membership_fee constraint
+    op.execute("alter table membership_fee drop constraint membership_fee_check")
+    op.execute("alter table membership_fee add constraint membership_fee_check check (begins_on <= ends_on)")
+
 
 def downgrade():
     op.drop_constraint('building_fee_account_id_fkey', 'building', type_='foreignkey')
@@ -147,3 +151,6 @@ def downgrade():
 
     op.drop_table("room_history_entry")
     op.execute('drop function if exists room_history_entry_uniqueness();')
+
+    op.execute("alter table membership_fee drop constraint membership_fee_check")
+    op.execute("alter table membership_fee add constraint membership_fee_check check (begins_on < ends_on)")

--- a/pycroft/model/alembic/versions/c11d3d8b16ae_building_fee_account.py
+++ b/pycroft/model/alembic/versions/c11d3d8b16ae_building_fee_account.py
@@ -31,6 +31,13 @@ def upgrade():
     # Make beginning of a membership not nullable as it makes no sense
     op.alter_column('membership', 'begins_at', nullable=False)
 
+    # Add missing check constraint for memberships
+    op.create_check_constraint(
+        "membership_check",
+        "membership",
+        "ends_at IS NULL OR begins_at <= ends_at",
+    )
+
     op.create_table('room_history_entry',
                     sa.Column('id', sa.Integer(), nullable=False),
                     sa.Column('user_id', sa.Integer(), nullable=False),
@@ -89,4 +96,5 @@ def downgrade():
     op.execute('drop trigger if exists "user_room_change_update_history_trigger" on "user"')
     op.execute('drop function if exists user_room_change_update_history();')
 
+    op.drop_constraint('membership_check', 'membership', type_='check')
     op.drop_table("room_history_entry")

--- a/pycroft/model/alembic/versions/c11d3d8b16ae_building_fee_account.py
+++ b/pycroft/model/alembic/versions/c11d3d8b16ae_building_fee_account.py
@@ -45,11 +45,12 @@ def upgrade():
                     sa.Column('begins_at', DateTimeTz, nullable=False,
                               server_default=sa.func.current_timestamp()),
                     sa.Column('ends_at', DateTimeTz, nullable=True),
+                    sa.ForeignKeyConstraint(('user_id',), ['user.id'], ),
+                    sa.ForeignKeyConstraint(('room_id',), ['room.id'], ),
+                    sa.PrimaryKeyConstraint('id'),
+                    sa.CheckConstraint("ends_at IS NULL OR begins_at <= ends_at"), )
 
-                    sa.ForeignKeyConstraint(['user_id'], ['user.id'], ),
-                    sa.ForeignKeyConstraint(['room_id'], ['room.id'], ),
-                    sa.PrimaryKeyConstraint('id')
-                    )
+    # Trigger to keep room history up-to-date
 
     op.execute('''
             create or replace function user_room_change_update_history() returns trigger

--- a/pycroft/model/alembic/versions/c11d3d8b16ae_building_fee_account.py
+++ b/pycroft/model/alembic/versions/c11d3d8b16ae_building_fee_account.py
@@ -23,11 +23,14 @@ def upgrade():
     op.create_foreign_key('building_fee_account_id_fkey', 'building', 'account',
                           ['fee_account_id'], ['id'])
 
+    # Make beginning of a membership not nullable as it makes no sense
+    op.alter_column('membership', 'begins_at', nullable=False)
+
     op.create_table('room_history_entry',
                     sa.Column('id', sa.Integer(), nullable=False),
                     sa.Column('user_id', sa.Integer(), nullable=False),
                     sa.Column('room_id', sa.Integer(), nullable=False),
-                    sa.Column('begins_at', DateTimeTz, nullable=True,
+                    sa.Column('begins_at', DateTimeTz, nullable=False,
                               server_default=sa.func.current_timestamp()),
                     sa.Column('ends_at', DateTimeTz, nullable=True),
 

--- a/pycroft/model/facilities.py
+++ b/pycroft/model/facilities.py
@@ -24,8 +24,7 @@ class Building(IntegerIdModel):
     street = Column(String(), nullable=False)
     wifi_available = Column(Boolean(), nullable=False, default=False)
 
-    # TODO: Change nullable to false and create new fee accounts
-    fee_account_id = Column(Integer, ForeignKey(Account.id), nullable=True)
+    fee_account_id = Column(Integer, ForeignKey(Account.id), nullable=False)
     fee_account = relationship(Account, backref=backref("building",
                                                         uselist=False))
 

--- a/pycroft/model/facilities.py
+++ b/pycroft/model/facilities.py
@@ -24,10 +24,11 @@ class Building(IntegerIdModel):
     street = Column(String(), nullable=False)
     wifi_available = Column(Boolean(), nullable=False, default=False)
 
-    fee_account_id = Column(Integer, ForeignKey(Account.id), nullable=False)
+    # TODO: Change nullable to false and create new fee accounts
+    fee_account_id = Column(Integer, ForeignKey(Account.id), nullable=True)
     fee_account = relationship(Account, backref=backref("building",
                                                         uselist=False))
-    
+
     __table_args__ = (UniqueConstraint("street", "number", name="building_address"),)
 
 

--- a/pycroft/model/facilities.py
+++ b/pycroft/model/facilities.py
@@ -9,6 +9,8 @@ from sqlalchemy.types import Boolean, Integer, String
 
 from pycroft.model.address import Address
 from pycroft.model.base import IntegerIdModel
+from pycroft.model.finance import Account
+
 
 class Site(IntegerIdModel):
     name = Column(String(), nullable=False)
@@ -22,6 +24,10 @@ class Building(IntegerIdModel):
     street = Column(String(), nullable=False)
     wifi_available = Column(Boolean(), nullable=False, default=False)
 
+    fee_account_id = Column(Integer, ForeignKey(Account.id), nullable=False)
+    fee_account = relationship(Account, backref=backref("building",
+                                                        uselist=False))
+    
     __table_args__ = (UniqueConstraint("street", "number", name="building_address"),)
 
 

--- a/pycroft/model/finance.py
+++ b/pycroft/model/finance.py
@@ -192,7 +192,7 @@ class Split(IntegerIdModel):
     transaction = relationship(Transaction,
                                backref=backref("splits",
                                                cascade="all, delete-orphan"))
-    __table_args = (
+    __table_args__ = (
         UniqueConstraint(transaction_id, account_id),
     )
 
@@ -343,7 +343,7 @@ class BankAccountActivity(IntegerIdModel):
                          backref=backref("bank_account_activity",
                                          uselist=False))
 
-    __table_args = (
+    __table_args__ = (
         ForeignKeyConstraint((transaction_id, account_id),
                              (Split.transaction_id, Split.account_id),
                              onupdate='CASCADE',

--- a/pycroft/model/finance.py
+++ b/pycroft/model/finance.py
@@ -213,9 +213,9 @@ manager.add_function(
           ELSE
             s := COALESCE(NEW, OLD);
           END IF;
-          
+
           SELECT COUNT(*) = 0 INTO transaction_deleted FROM "transaction" WHERE "id" = s.transaction_id;
-            
+
           SELECT COUNT(*), SUM(amount) INTO STRICT count, balance FROM split
               WHERE transaction_id = s.transaction_id;
           IF count < 2 AND NOT transaction_deleted THEN
@@ -391,7 +391,7 @@ manager.add_function(
           ELSE
             v_activity := COALESCE(NEW, OLD);
           END IF;
-          
+
           SELECT bank_account.account_id INTO v_bank_account_account_id FROM bank_account
               WHERE bank_account.id = v_activity.bank_account_id;
           SELECT * INTO v_split FROM split

--- a/pycroft/model/finance.py
+++ b/pycroft/model/finance.py
@@ -51,7 +51,7 @@ class MembershipFee(IntegerIdModel):
         return date in closed(self.begins_on, self.ends_on)
 
     __table_args__ = (
-        CheckConstraint('begins_on < ends_on'),
+        CheckConstraint('begins_on <= ends_on'),
     )
 
 

--- a/pycroft/model/net.py
+++ b/pycroft/model/net.py
@@ -13,7 +13,7 @@ class VLAN(IntegerIdModel):
     name = Column(String(127), nullable=False)
     vid = Column(Integer, nullable=False)
 
-    __table_args = (
+    __table_args__ = (
         CheckConstraint(between(vid, 1, 4094)),
     )
     switch_ports = relationship('SwitchPort', secondary='switch_port_default_vlans',

--- a/pycroft/model/user.py
+++ b/pycroft/model/user.py
@@ -441,11 +441,6 @@ class RoomHistoryEntry(IntegerIdModel, IntervalModel):
     user = relationship(User, backref=backref("room_history_entries",
                                               order_by='RoomHistoryEntry.id'))
 
-    __table_args = (
-        CheckConstraint("ends_at IS NULL OR "
-                        "ends_at <= NOW()")
-    )
-
 
 manager.add_function(
     User.__table__,

--- a/pycroft/model/user.py
+++ b/pycroft/model/user.py
@@ -474,12 +474,14 @@ class RoomHistoryEntry(IntegerIdModel, IntervalModel):
     room_id = Column(Integer, ForeignKey("room.id", ondelete="CASCADE"),
                      nullable=False, index=True)
     room = relationship(Room, backref=backref(name="room_history_entries",
-                                              order_by='RoomHistoryEntry.id'))
+                                              order_by='RoomHistoryEntry.id',
+                                              passive_deletes=True))
 
     user_id = Column(Integer, ForeignKey(User.id, ondelete="CASCADE"),
                      nullable=False, index=True)
     user = relationship(User, backref=backref("room_history_entries",
-                                              order_by='RoomHistoryEntry.id'))
+                                              order_by='RoomHistoryEntry.id',
+                                              passive_deletes=True))
 
 
 manager.add_function(

--- a/pycroft/model/user.py
+++ b/pycroft/model/user.py
@@ -506,7 +506,7 @@ manager.add_function(
               AND NEW.user_id = rhe.user_id AND NEW.id != rhe.id;
 
             IF count > 0 THEN
-                RAISE EXCEPTION 'entry overlaps with entry %',
+                RAISE EXCEPTION 'entry overlaps with entry %%',
                 rhe_id
                 USING ERRCODE = 'integrity_constraint_violation';
             END IF;

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -16,6 +16,7 @@ from fixture import SQLAlchemyFixture, DataTestCase
 from fixture.util import start_debug, stop_debug
 from sqlalchemy.exc import IntegrityError
 from sqlalchemy.orm import sessionmaker, scoped_session
+from sqlalchemy.orm.session import close_all_sessions
 from sqlalchemy.pool import SingletonThreadPool
 import sys
 
@@ -94,6 +95,7 @@ class SQLAlchemyTestCase(unittest.TestCase):
 
     def tearDown(self):
         self._rollback()
+        close_all_sessions()
         super(SQLAlchemyTestCase, self).tearDown()
 
     def cleanup(self):
@@ -154,13 +156,14 @@ class FixtureDataTestBase(SQLAlchemyTestCase, DataTestCase, unittest.TestCase):
     """
     @classmethod
     def setUpClass(cls):
-        SQLAlchemyTestCase.setUpClass()
+        super().setUpClass()
         cls.fixture = SQLAlchemyFixture(
             env=_all, style=NamedDataStyle(),
             engine=connection
         )
 
     def cleanup(self):
+        """Override of SQLAlchemyTestCase.cleanup"""
         self.data.teardown()
         super(FixtureDataTestBase, self).cleanup()
 

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -161,8 +161,8 @@ class FixtureDataTestBase(SQLAlchemyTestCase, DataTestCase, unittest.TestCase):
         )
 
     def cleanup(self):
-        super(FixtureDataTestBase, self).cleanup()
         self.data.teardown()
+        super(FixtureDataTestBase, self).cleanup()
 
 
 class DialectSpecificTestCase(FixtureDataTestBase):

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -164,8 +164,8 @@ class FixtureDataTestBase(SQLAlchemyTestCase, DataTestCase, unittest.TestCase):
 
     def cleanup(self):
         """Override of SQLAlchemyTestCase.cleanup"""
-        self.data.teardown()
         super(FixtureDataTestBase, self).cleanup()
+        self.data.teardown()
 
 
 class DialectSpecificTestCase(FixtureDataTestBase):

--- a/tests/factories/config.py
+++ b/tests/factories/config.py
@@ -26,7 +26,9 @@ class ConfigFactory(BaseFactory):
     cache_group = SubFactory(PropertyGroupFactory)
     traffic_limit_exceeded_group = SubFactory(PropertyGroupFactory)
     external_group = SubFactory(PropertyGroupFactory)
-    payment_in_default_group = SubFactory(PropertyGroupFactory)
+    payment_in_default_group = SubFactory(PropertyGroupFactory,
+                                          granted=frozenset(("payment_in_default",)),
+                                          denied=frozenset(("network_access", "userwww", "userdb")))
     blocked_group = SubFactory(PropertyGroupFactory)
     caretaker_group = SubFactory(PropertyGroupFactory)
     treasurer_group = SubFactory(PropertyGroupFactory)

--- a/tests/factories/facilities.py
+++ b/tests/factories/facilities.py
@@ -7,6 +7,7 @@ from factory.faker import Faker
 
 from pycroft.model.facilities import Site, Building, Room
 from pycroft.model.port import PatchPort
+from .finance import AccountFactory
 from .base import BaseFactory
 from .address import AddressFactory
 
@@ -27,6 +28,7 @@ class BuildingFactory(BaseFactory):
     number = Sequence(lambda n: n)
     street = LazyAttribute(lambda b: b.site.name)
     short_name = LazyAttribute(lambda b: "{}{}".format(b.street[:3], b.number))
+    fee_account = SubFactory(AccountFactory, type='REVENUE')
 
 
 class RoomFactory(BaseFactory):

--- a/tests/factories/property.py
+++ b/tests/factories/property.py
@@ -3,6 +3,7 @@ from itertools import chain
 
 import factory
 
+from pycroft.model import session
 from pycroft.model.user import Membership, PropertyGroup
 
 from .base import BaseFactory
@@ -12,7 +13,6 @@ from .user import UserFactory
 class MembershipFactory(BaseFactory):
     class Meta:
         model = Membership
-    begins_at = None
     ends_at = None
 
     user = factory.SubFactory(UserFactory)

--- a/tests/factories/user.py
+++ b/tests/factories/user.py
@@ -33,6 +33,9 @@ class UserFactory(BaseFactory):
 
             rhe.begins_at = self.registered_at
 
+            for key, value in kwargs.items():
+                setattr(rhe, key, value)
+
 
 class UserWithHostFactory(UserFactory):
     host = factory.RelatedFactory('tests.factories.host.HostFactory', 'owner')

--- a/tests/factories/user.py
+++ b/tests/factories/user.py
@@ -36,3 +36,7 @@ class UserFactory(BaseFactory):
 
 class UserWithHostFactory(UserFactory):
     host = factory.RelatedFactory('tests.factories.host.HostFactory', 'owner')
+
+
+class UserWithMembershipFactory(UserFactory):
+    membership = factory.RelatedFactory('tests.factories.property.MembershipFactory', 'user')

--- a/tests/factories/user.py
+++ b/tests/factories/user.py
@@ -5,10 +5,11 @@
 import factory
 from factory.faker import Faker
 
-from pycroft.model.user import User
+from pycroft.model.user import User, RoomHistoryEntry
 from .base import BaseFactory
 from .facilities import RoomFactory
 from .finance import AccountFactory
+
 
 class UserFactory(BaseFactory):
     class Meta:
@@ -22,6 +23,15 @@ class UserFactory(BaseFactory):
     account = factory.SubFactory(AccountFactory, type="USER_ASSET")
     room = factory.SubFactory(RoomFactory)
     address = factory.SelfAttribute('room.address')
+
+    @factory.post_generation
+    def room_history_entries(self, create, extracted, **kwargs):
+        if self.room is not None:
+            # Set room history entry begin to registration date
+
+            rhe = RoomHistoryEntry.q.filter_by(user=self, room=self.room).one()
+
+            rhe.begins_at = self.registered_at
 
 
 class UserWithHostFactory(UserFactory):

--- a/tests/fixtures/dummy/facilities.py
+++ b/tests/fixtures/dummy/facilities.py
@@ -4,6 +4,7 @@
 from fixture import DataSet
 
 from .address import AddressData
+from .finance import AccountData
 
 
 class SiteData(DataSet):
@@ -17,12 +18,14 @@ class BuildingData(DataSet):
         street = "dummy"
         number = "01"
         short_name = "abc"
+        fee_account = AccountData.dummy_revenue
 
     class dummy_house2:
         site = SiteData.dummy
         street = "dummy"
         number = "02"
         short_name = "def"
+        fee_account = AccountData.dummy_revenue
 
 
 class RoomData(DataSet):

--- a/tests/fixtures/dummy/finance.py
+++ b/tests/fixtures/dummy/finance.py
@@ -8,23 +8,6 @@ from fixture import DataSet
 today = datetime.utcnow().date()
 
 
-class MembershipFeeData(DataSet):
-    class dummy_fee1:
-        name = u"first fee"
-        registration_fee = 5.00
-        regular_fee = 5.00
-        reduced_fee = 1.00
-        late_fee = 2.50
-        booking_begin = timedelta(2)
-        booking_end = timedelta(14)
-        reduced_fee_threshold = timedelta(10)
-        payment_deadline = timedelta(14)
-        payment_deadline_final = timedelta(62)
-        not_allowed_overdraft_late_fee = 2.00
-        begins_on = today - timedelta(days=31)
-        ends_on = today
-
-
 class AccountData(DataSet):
     class bank_account:
         name = u"Bankkonto 1020304050"

--- a/tests/lib/finance_fixtures.py
+++ b/tests/lib/finance_fixtures.py
@@ -12,39 +12,6 @@ from tests.fixtures.dummy.facilities import RoomData
 
 today = datetime.utcnow().date()
 
-
-class MembershipFeeData(DataSet):
-    class fee_one:
-        name = u"first fee"
-        regular_fee = 5.00
-        booking_begin = timedelta(2)
-        booking_end = timedelta(14)
-        payment_deadline = timedelta(14)
-        payment_deadline_final = timedelta(62)
-        begins_on = today - timedelta(days=90)
-        ends_on = today - timedelta(days=61)
-
-    class fee_two:
-        name = u"seconds fee"
-        regular_fee = 5.00
-        booking_begin = timedelta(2)
-        booking_end = timedelta(14)
-        payment_deadline = timedelta(14)
-        payment_deadline_final = timedelta(62)
-        begins_on = today - timedelta(days=60)
-        ends_on = today - timedelta(days=31)
-
-    class fee_three:
-        name = u"third fee"
-        regular_fee = 5.00
-        booking_begin = timedelta(2)
-        booking_end = timedelta(14)
-        payment_deadline = timedelta(14)
-        payment_deadline_final = timedelta(62)
-        begins_on = today - timedelta(days=30)
-        ends_on = today
-
-
 class AccountData(DataSet):
     class bank_account:
         name = u"Bankkonto 3120219540"
@@ -75,7 +42,7 @@ class UserData(DataSet):
     class dummy_1:
         login = u"dummy1"
         name = u"Dummy Dummy"
-        registered_at = datetime.combine(MembershipFeeData.fee_one.begins_on + timedelta(days=1), time.min)
+        registered_at = datetime(2019, 1, 1)
         room = RoomData.dummy_room1
         address = room.address
         account = AccountData.user_account
@@ -83,7 +50,7 @@ class UserData(DataSet):
     class dummy_2:
         login = u"dummy2"
         name = u"Dummy Dummy"
-        registered_at = datetime.combine(MembershipFeeData.fee_three.begins_on + timedelta(days=2), time.min)
+        registered_at = datetime(2019, 1, 1)
         room = RoomData.dummy_room1
         address = room.address
         account = AccountData.user_account_early
@@ -91,7 +58,7 @@ class UserData(DataSet):
     class dummy_14:
         login = u"dummy14"
         name = u"Dummy Dummy"
-        registered_at = datetime.combine(MembershipFeeData.fee_one.begins_on + timedelta(days=14), time.min)
+        registered_at = datetime(2019, 1, 1)
         room = RoomData.dummy_room1
         address = room.address
         account = AccountData.user_account_grace
@@ -99,7 +66,7 @@ class UserData(DataSet):
     class dummy_15:
         login = u"dummy15"
         name = u"Dummy Dummy"
-        registered_at = datetime.combine(MembershipFeeData.fee_two.begins_on - timedelta(days=15), time.min)
+        registered_at = datetime(2019, 1, 1)
         room = RoomData.dummy_room1
         address = room.address
         account = AccountData.user_account_no_grace

--- a/tests/lib/test_finance.py
+++ b/tests/lib/test_finance.py
@@ -31,12 +31,11 @@ from tests.factories.finance import MembershipFeeFactory, TransactionFactory, \
     AccountFactory
 from tests.fixtures.config import ConfigData, PropertyGroupData, PropertyData
 from tests.lib.finance_fixtures import (
-    AccountData, BankAccountData, MembershipData, UserData,
-    MembershipFeeData)
+    AccountData, BankAccountData, MembershipData, UserData)
 
 
 class Test_010_BankAccount(FixtureDataTestBase):
-    datasets = [AccountData, BankAccountData, MembershipFeeData, UserData]
+    datasets = [AccountData, BankAccountData, UserData]
 
     def setUp(self):
         super(Test_010_BankAccount, self).setUp()

--- a/tests/lib/test_user.py
+++ b/tests/lib/test_user.py
@@ -5,7 +5,9 @@
 from datetime import timedelta
 
 from pycroft.lib.facilities import get_room
-from tests.factories import UserWithHostFactory, MembershipFactory, UserFactory, RoomFactory
+from pycroft.lib.user import move, move_out, move_in
+from tests.factories import UserWithHostFactory, MembershipFactory, UserFactory, RoomFactory, \
+    ConfigFactory
 
 from pycroft import config
 from pycroft.helpers.i18n import localized
@@ -14,7 +16,7 @@ from pycroft.lib import user as UserHelper
 from pycroft.model import (
     user, facilities, session, host)
 from pycroft.model.port import PatchPort
-from tests import FixtureDataTestBase, FactoryWithConfigDataTestBase
+from tests import FixtureDataTestBase, FactoryWithConfigDataTestBase, FactoryDataTestBase
 from tests.factories.address import AddressFactory
 from tests.fixtures import network_access
 from tests.fixtures.config import ConfigData, PropertyData
@@ -393,3 +395,72 @@ class UserWithNetworkAccessTestCase(FixtureDataTestBase):
 
         self.assertEqual(unblocked_user.log_entries[0].author, unblocked_user)
         self.assert_violation_membership(unblocked_user, subinterval=blocked_during)
+
+
+class UserRoomHistoryTestCase(FactoryDataTestBase):
+    def create_factories(self):
+        ConfigFactory.create()
+
+        self.processor = UserFactory.create()
+
+        self.user = UserFactory()
+        self.user_no_room = UserFactory(room=None, address=AddressFactory())
+        self.room = RoomFactory()
+
+    def test_room_history_create(self):
+        self.assertEqual(1, len(self.user.room_history_entries), "more than one room history entry")
+
+        rhe = self.user.room_history_entries[0]
+
+        self.assertEqual(self.user.room, rhe.room)
+        self.assertIsNotNone(rhe.begins_at)
+        self.assertIsNone(rhe.ends_at)
+
+    def test_room_history_move(self):
+        session.session.refresh(self.room)
+
+        old_room = self.user.room
+
+        move(self.user, self.room.building_id, self.room.level, self.room.number, self.processor)
+
+        found_old = False
+        found_new = False
+
+        for rhe in self.user.room_history_entries:
+            self.assertIsNotNone(rhe.begins_at)
+
+            if rhe.room == old_room:
+                self.assertIsNotNone(rhe.ends_at)
+                found_old = True
+            elif rhe.room == self.room:
+                self.assertIsNone(rhe.ends_at)
+                found_new = True
+
+        self.assertTrue(found_new, "Did not find new history entry")
+        self.assertTrue(found_old, "Did not find old history entry")
+
+    def test_room_history_move_out(self):
+        move_out(self.user, comment="test", processor=self.processor, when=session.utcnow())
+
+        session.session.commit()
+
+        rhe = self.user.room_history_entries[0]
+
+        self.assertIsNotNone(rhe.begins_at)
+        self.assertIsNotNone(rhe.ends_at)
+
+    def test_room_history_move_in(self):
+        self.assertEqual(0, len(self.user_no_room.room_history_entries))
+
+        move_in(self.user_no_room, self.room.building.id, self.room.level, self.room.number,
+                mac=None, processor=self.processor)
+
+        session.session.commit()
+
+        rhe = self.user_no_room.room_history_entries[0]
+
+        self.assertEqual(rhe.room, self.room)
+
+        self.assertIsNotNone(rhe.begins_at)
+        self.assertIsNone(rhe.ends_at)
+

--- a/tests/lib/test_user.py
+++ b/tests/lib/test_user.py
@@ -19,7 +19,7 @@ from tests.factories.address import AddressFactory
 from tests.fixtures import network_access
 from tests.fixtures.config import ConfigData, PropertyData
 from tests.fixtures.dummy.facilities import BuildingData, RoomData
-from tests.fixtures.dummy.finance import AccountData, MembershipFeeData
+from tests.fixtures.dummy.finance import AccountData
 from tests.fixtures.dummy.host import (
     IPData, PatchPortData, InterfaceData, HostData)
 from tests.fixtures.dummy.net import SubnetData, VLANData
@@ -70,7 +70,7 @@ class Test_010_User_Move(FixtureDataTestBase):
 
 class Test_020_User_Move_In(FixtureDataTestBase):
     datasets = (AccountData, BuildingData, ConfigData, IPData, PropertyData,
-                RoomData, MembershipFeeData, SubnetData, PatchPortData,
+                RoomData, SubnetData, PatchPortData,
                 UserData, HostData, InterfaceData, VLANData)
 
     def setUp(self):
@@ -234,8 +234,7 @@ class MovedInUserTestCase(FactoryWithConfigDataTestBase):
 
 
 class Test_030_User_Move_Out_And_Back_In(FixtureDataTestBase):
-    datasets = (AccountData, ConfigData, IPData, MembershipFeeData,
-                PatchPortData)
+    datasets = (AccountData, ConfigData, IPData, PatchPortData)
 
     def setUp(self):
         super().setUp()

--- a/web/blueprints/finance/__init__.py
+++ b/web/blueprints/finance/__init__.py
@@ -388,7 +388,7 @@ def bank_account_activities_edit(activity_id):
                                   if split.account_id == credit_account.id)
             session.add(activity)
 
-            end_payment_in_default_memberships()
+            end_payment_in_default_memberships(current_user)
 
             session.commit()
 
@@ -480,7 +480,7 @@ def bank_account_activities_do_match():
 
                 matched.append((activity, user))
 
-        end_payment_in_default_memberships()
+        end_payment_in_default_memberships(current_user)
 
         session.flush()
         session.commit()
@@ -900,7 +900,7 @@ def transactions_create():
             valid_on=form.valid_on.data,
         )
 
-        end_payment_in_default_memberships()
+        end_payment_in_default_memberships(current_user)
 
         session.commit()
 
@@ -1108,7 +1108,7 @@ def membership_fee_edit(fee_id):
 @bp.route('/membership_fees/handle_payments_in_default', methods=("GET", "POST"))
 @access.require('finance_change')
 def handle_payments_in_default():
-    finance.end_payment_in_default_memberships()
+    finance.end_payment_in_default_memberships(current_user)
 
     users_pid_membership_all, users_membership_terminated_all = finance.get_users_with_payment_in_default()
 

--- a/web/blueprints/finance/__init__.py
+++ b/web/blueprints/finance/__init__.py
@@ -973,7 +973,11 @@ def membership_fee_users_due_json(fee_id):
                  'href': url_for("user.user_show", user_id=user['id'])},
         'amount': fee_amount,
         'description': fee_description,
-        'valid_on': fee.ends_on
+        'valid_on': fee.ends_on,
+        'fee_account_id':{
+            'title': str(user['fee_account_id']),
+            'href': url_for(".accounts_show", account_id=user['fee_account_id'])
+        },
     } for user in affected_users])
 
 

--- a/web/blueprints/finance/tables.py
+++ b/web/blueprints/finance/tables.py
@@ -123,6 +123,7 @@ class UsersDueTable(BootstrapTable):
     user = LinkColumn("Name")
     valid_on = Column("Gültig am")
     description = Column("Beschreibung")
+    fee_account_id = LinkColumn("Beitragsonto")
     amount = Column("Betrag", formatter="table.coloredFormatter")
 
 

--- a/web/blueprints/host/forms.py
+++ b/web/blueprints/host/forms.py
@@ -10,14 +10,16 @@ from web.form.fields.validators import MacAddress
 
 
 class HostForm(SelectRoomForm):
-    owner_id = UserIDField(u"Besitzer-ID")
-    name = TextField(u"Name", validators=[Optional()],
-                     description=u"z.B. TP-LINK WR841, FritzBox 4040 oder MacBook")
+    owner_id = UserIDField("Besitzer-ID")
+    name = TextField("Name", validators=[Optional()],
+                     description="z.B. TP-LINK WR841, FritzBox 4040 oder MacBook")
 
     _order = ("name", "owner_id")
 
 
 class InterfaceForm(Form):
-    name = TextField(u"Name",description=u"z.B. eth0, en0 oder enp0s29u1u1u5")
-    mac = MacField(u"MAC", [MacAddress(message=u"MAC ist ungültig!")])
+    name = TextField("Name",
+                     description="z.B. eth0, en0 oder enp0s29u1u1u5",
+                     validators=[Optional()])
+    mac = MacField("MAC", [MacAddress(message="MAC ist ungültig!")])
     ips = SelectMultipleField(u"IPs", validators=[Optional()])

--- a/web/blueprints/user/__init__.py
+++ b/web/blueprints/user/__init__.py
@@ -356,11 +356,38 @@ def user_show(user_id):
         room_history_table=RoomHistoryTable(
             data_url=url_for(".room_history_json", user_id=user.id)
         ),
-        count={
-            'tasks': len(user.tasks),
-            'rooms': len(user.room_history_entries),
-            'hosts': len(user.hosts),
-        }
+        tabs=[
+            {
+                'id': 'hosts',
+                'name': 'Hosts & Interfaces',
+                'badge': len(user.hosts)
+            },
+            {
+                'id': 'tasks',
+                'name': 'Aufgaben',
+                'badge': len(user.tasks),
+                'badge_color': '#d9534f' if len(user.tasks) > 0 else None
+            },
+            {
+                'id': 'logs',
+                'name': 'Logs',
+                'badge': len(user.log_entries)
+            },
+            {
+                'id': 'finance',
+                'name': 'Finanzen',
+            },
+            {
+                'id': 'groups',
+                'name': 'Gruppen',
+                'badge': len(user.active_memberships())
+            },
+            {
+                'id': 'room_history',
+                'name': 'Wohnorte',
+                'badge': len(user.room_history_entries)
+            },
+        ]
     )
 
 

--- a/web/blueprints/user/__init__.py
+++ b/web/blueprints/user/__init__.py
@@ -374,6 +374,10 @@ def user_show(user_id):
                 'badge': len(user.log_entries)
             },
             {
+                'id': 'traffic',
+                'name': 'Traffic',
+            },
+            {
                 'id': 'finance',
                 'name': 'Finanzen',
             },

--- a/web/blueprints/user/tables.py
+++ b/web/blueprints/user/tables.py
@@ -78,3 +78,8 @@ class TrafficTopTable(BootstrapTable):
     url = LinkColumn("Name")
     traffic_for_days = Column("Traffic", formatter='table.byteFormatterBinary')
 
+
+class RoomHistoryTable(BootstrapTable):
+    room = LinkColumn("Wohnort")
+    begins_at = DateColumn("Von")
+    ends_at = DateColumn("Bis")

--- a/web/templates/user/_user_show_room_history.html
+++ b/web/templates/user/_user_show_room_history.html
@@ -1,0 +1,1 @@
+{{ room_history_table.render('room_history_table') }}

--- a/web/templates/user/user_show.html
+++ b/web/templates/user/user_show.html
@@ -10,82 +10,59 @@
 {% import "macros/resources.html" as resources %}
 
 {% block content %}
-    <div class="subnav">
-        <ul class="nav nav-pills">
-            <li><a href="#master-data">Stammdaten</a></li>
-            <li><a href="#hosts">Hosts</a></li>
-            <li><a href="#tasks">Aufgaben</a></li>
-            <li><a href="#traffic">Traffic</a></li>
-            <li><a href="#logs">Logs</a></li>
-            {% if current_user is privileged_for('finance_show') %}
-                <li><a href="#finance">Konto</a></li>
-            {% endif %}
-            <li><a href="#groups">Gruppen</a></li>
-            <li class="pull-right"><a data-toggle="scroll-top" href="#"><span class="glyphicon glyphicon-chevron-up"></span></a></li>
-        </ul>
+  {# Stammdaten #}
+  <section id="master-data">
+    <div class="body">
+      {% include "user/_user_show_basedata.html" with context %}
     </div>
+  </section>
 
-    {# Stammdaten #}
-    <section id="master-data">
-        <div class="body">
-            {% include "user/_user_show_basedata.html" with context %}
-        </div>
-    </section>
+  <br/>
 
-    <div class="row">
-        <div class="col-md-6">
-            {# Hosts #}
-            <section id="hosts">
-                <div class="page-header"><h2>Hosts & Interfaces</h2></div>
-                <div id="tbl_devices">
-                    {% include "user/_user_show_hosts.html" with context %}
-                </div>
-            </section>
+  <div class="row">
+    <div class="col-xs-12">
+      <ul class="nav nav-tabs">
+        <li class="active"><a href="#hosts" data-toggle="tab">
+          Hosts & Interfaces
+          {% if count['hosts'] %}&nbsp;<span class="badge">{{ count['hosts'] }}</span>{% endif %}
+        </a></li>
+        <li><a href="#tasks" data-toggle="tab">
+          Aufgaben
+          {% if count['tasks'] %}&nbsp;<span style="background-color: #d9534f;" class="badge">{{ count['tasks'] }}</span>{% endif %}
+        </a></li>
+        <li><a href="#traffic" data-toggle="tab">Traffic</a></li>
+        <li><a href="#logs" data-toggle="tab">Logs</a></li>
+        <li><a href="#finances" data-toggle="tab">Finanzen</a></li>
+        <li><a href="#groups" data-toggle="tab">Gruppen</a></li>
+        <li><a href="#room_history" data-toggle="tab">
+          Wohnorte
+          {% if count['rooms'] %}&nbsp;<span class="badge">{{ count['rooms'] }}</span>{% endif %}
+        </a></li>
+      </ul>
+
+      <div class="tab-content">
+        <div class="tab-pane fade in active" id="hosts">
+          {% include "user/_user_show_hosts.html" with context %}
         </div>
-        <div class="col-md-6">
-            <section id="tasks">
-                <div class="page-header"><h2>Aufgaben</h2></div>
-                <div id="tbl_tasks">
-                    {% include "user/_user_show_tasks.html" with context %}
-                </div>
-            </section>
+        <div class="tab-pane fade" id="tasks">
+          {% include "user/_user_show_tasks.html" with context %}
         </div>
+        <div class="tab-pane fade" id="traffic">
+          {% include "user/_user_show_traffic.html" with context %}
+        </div>
+        <div class="tab-pane fade" id="logs">
+          {% include "user/_user_show_logs.html" with context %}
+        </div>
+        <div class="tab-pane fade" id="finances">
+          {% include "user/_user_show_finance.html" with context %}
+        </div>
+        <div class="tab-pane fade" id="groups">
+          {% include "user/_user_show_groups.html" with context %}
+        </div>
+        <div class="tab-pane fade" id="room_history">
+          {% include "user/_user_show_room_history.html" with context %}
+        </div>
+      </div>
     </div>
-
-
-    {# Traffic #}
-    <section id="traffic">
-        <div class="page-header"><h2>Traffic</h2></div>
-        <div class="body">
-            {% include "user/_user_show_traffic.html" with context %}
-        </div>
-    </section>
-
-    {# Logs zum Nutzers #}
-    <section id="logs">
-        <div class="page-header"><h2>Logs</h2></div>
-        <div class="body">
-            {% include "user/_user_show_logs.html" with context %}
-        </div>
-    </section>
-
-    {# Konto des Nutzers #}
-    {% if current_user is privileged_for('finance_show') %}
-        <section id="finance">
-            <div class="page-header"><h2>Konto</h2></div>
-            <div class="body">
-                {% include "user/_user_show_finance.html" with context %}
-            </div>
-        </section>
-    {% endif %}
-
-    {# Gruppen des Nutzers #}
-    <section id="groups">
-        <div class="page-header"><h2>Gruppen</h2></div>
-        <div id="tbl_groups" class="body">
-            {% include "user/_user_show_groups.html" with context %}
-        </div>
-    </section>
+  </div>
 {% endblock %}
-
-{% do resources.link_script_file('navigation.js' | require) %}

--- a/web/templates/user/user_show.html
+++ b/web/templates/user/user_show.html
@@ -22,47 +22,34 @@
   <div class="row">
     <div class="col-xs-12">
       <ul class="nav nav-tabs">
-        <li class="active"><a href="#hosts" data-toggle="tab">
-          Hosts & Interfaces
-          {% if count['hosts'] %}&nbsp;<span class="badge">{{ count['hosts'] }}</span>{% endif %}
-        </a></li>
-        <li><a href="#tasks" data-toggle="tab">
-          Aufgaben
-          {% if count['tasks'] %}&nbsp;<span style="background-color: #d9534f;" class="badge">{{ count['tasks'] }}</span>{% endif %}
-        </a></li>
-        <li><a href="#traffic" data-toggle="tab">Traffic</a></li>
-        <li><a href="#logs" data-toggle="tab">Logs</a></li>
-        <li><a href="#finances" data-toggle="tab">Finanzen</a></li>
-        <li><a href="#groups" data-toggle="tab">Gruppen</a></li>
-        <li><a href="#room_history" data-toggle="tab">
-          Wohnorte
-          {% if count['rooms'] %}&nbsp;<span class="badge">{{ count['rooms'] }}</span>{% endif %}
-        </a></li>
+        {% for tab in tabs %}
+          <li class="{{ "active" if tab.id == 'hosts' else "" }}">
+            <a href="#{{ tab.id }}" data-toggle="tab">
+              {{ tab.name }}
+              {% if 'badge' in tab and tab.badge %}
+                &nbsp;
+                <span class="badge" style="{{ "background-color: " + tab.badge_color if 'badge_color' in tab else "" }}">
+                  {{ tab.badge }}
+                </span>
+              {% endif %}
+            </a>
+          </li>
+        {% endfor %}
       </ul>
 
       <div class="tab-content">
-        <div class="tab-pane fade in active" id="hosts">
-          {% include "user/_user_show_hosts.html" with context %}
-        </div>
-        <div class="tab-pane fade" id="tasks">
-          {% include "user/_user_show_tasks.html" with context %}
-        </div>
-        <div class="tab-pane fade" id="traffic">
-          {% include "user/_user_show_traffic.html" with context %}
-        </div>
-        <div class="tab-pane fade" id="logs">
-          {% include "user/_user_show_logs.html" with context %}
-        </div>
-        <div class="tab-pane fade" id="finances">
-          {% include "user/_user_show_finance.html" with context %}
-        </div>
-        <div class="tab-pane fade" id="groups">
-          {% include "user/_user_show_groups.html" with context %}
-        </div>
-        <div class="tab-pane fade" id="room_history">
-          {% include "user/_user_show_room_history.html" with context %}
-        </div>
+        {% for tab in tabs %}
+          <div class="tab-pane fade {{ "in active" if tab.id == 'hosts' else "" }}" id="{{ tab.id }}">
+            {% include "user/_user_show_" + tab.id + ".html" with context %}
+          </div>
+        {% endfor %}
       </div>
+    </div>
+  </div>
+  <div class="row">
+    <div class="col-xs-12">
+      <h2>Traffic</h2>
+      {% include "user/_user_show_traffic.html" with context %}
     </div>
   </div>
 {% endblock %}

--- a/web/templates/user/user_show.html
+++ b/web/templates/user/user_show.html
@@ -46,10 +46,4 @@
       </div>
     </div>
   </div>
-  <div class="row">
-    <div class="col-xs-12">
-      <h2>Traffic</h2>
-      {% include "user/_user_show_traffic.html" with context %}
-    </div>
-  </div>
 {% endblock %}


### PR DESCRIPTION
This PR adds the ability to book membership fees separated by dormitory (closes #328).
An additional room history is created for every user that keeps track in which period a user lived in a room.
If a fee is booked, it is checked in which room a user lived at the end of the fee period and at the beginning of the period as an alternative.
By default, the current fee account is used and the account of a dormitory can be changed in the database.

This PR also add test cases for fee booking and handling of overdue users. (closes #197).

I also changed the design of the user overview to a tabbed layout (closes #367).
