### PR TITLE
Add user to a `pre-member` group, if the move-in date is in the future

### DIFF
--- a/pycroft/lib/user.py
+++ b/pycroft/lib/user.py
@@ -375,9 +375,9 @@ def move_in(
         user.birthdate = birthdate
 
     if begin_membership:
-        if user.member_of(config.external_group):
-            remove_member_of(user, config.external_group, processor,
-                             closedopen(session.utcnow(), None))
+        for group in {config.external_group, config.pre_member_group}:
+            if user.member_of(group):
+                remove_member_of(user, group, processor, closedopen(session.utcnow(), None))
 
         for group in {config.member_group, config.network_access_group}:
             if not user.member_of(group):
@@ -1159,7 +1159,7 @@ def finish_member_request(prm: PreMember, processor: Optional[User],
 
     if move_in_datetime > session.utcnow():
         make_member_of(user, config.pre_member_group, processor,
-                       closed(session.utcnow(), move_in_datetime + timedelta(hours=3)))
+                       closed(session.utcnow(), None))
 
     session.session.delete(prm)
 

--- a/pycroft/lib/user.py
+++ b/pycroft/lib/user.py
@@ -1250,12 +1250,21 @@ def merge_member_request(user: User, prm: PreMember, merge_name: bool, merge_ema
             if user.room:
                 move(user, prm.room.building_id, prm.room.level, prm.room.number,
                      processor=processor, when=move_in_datetime)
+
+                if not user.member_of(config.member_group):
+                    make_member_of(user, config.member_group, processor,
+                                   closed(move_in_datetime, None))
+
+                    if move_in_datetime > session.utcnow():
+                        make_member_of(user, config.pre_member_group, processor,
+                                       closed(session.utcnow(), move_in_datetime))
             else:
                 move_in(user, prm.room.building_id, prm.room.level, prm.room.number,
                         mac=None, processor=processor, when=move_in_datetime)
 
-    if not user.member_of(config.member_group):
-        make_member_of(user, config.member_group, processor, closed(move_in_datetime, None))
+                if move_in_datetime > session.utcnow():
+                    make_member_of(user, config.pre_member_group, processor,
+                                   closed(session.utcnow(), None))
 
     if merge_birthdate:
         user = edit_birthdate(user, prm.birthdate, processor)

--- a/pycroft/lib/user.py
+++ b/pycroft/lib/user.py
@@ -1157,6 +1157,10 @@ def finish_member_request(prm: PreMember, processor: Optional[User],
     message = deferred_gettext("Created from registration {}.").format(str(prm.id)).to_json()
     log_user_event(message, processor, user)
 
+    if move_in_datetime > session.utcnow():
+        make_member_of(user, config.pre_member_group, processor,
+                       closed(session.utcnow(), move_in_datetime + timedelta(hours=3)))
+
     session.session.delete(prm)
 
     return user

--- a/pycroft/model/alembic/versions/27f7f8832dfa_add_pre_member_group.py
+++ b/pycroft/model/alembic/versions/27f7f8832dfa_add_pre_member_group.py
@@ -1,0 +1,29 @@
+"""add pre member account
+
+Revision ID: 27f7f8832dfa
+Revises: fb8d553a7268
+Create Date: 2021-06-02 10:00:00
+
+"""
+from alembic import op
+import sqlalchemy as sa
+
+# revision identifiers, used by Alembic.
+revision = '27f7f8832dfa'
+down_revision = 'fb8d553a7268'
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.add_column('config', sa.Column('pre_member_group_id', sa.Integer(), nullable=False,
+                                      server_default='20'))
+    op.create_foreign_key('config_pre_member_group_id_fkey',
+                          'config', 'property_group', ['pre_member_group_id'], ['id'])
+
+    op.alter_column('config', 'pre_member_group_id', server_default=None)
+
+
+def downgrade():
+    op.drop_column('config', 'pre_member_group_id')
+    op.drop_constraint('config_pre_member_group_id_fkey', 'config', type_='foreignkey')

--- a/pycroft/model/alembic/versions/27f7f8832dfa_add_pre_member_group.py
+++ b/pycroft/model/alembic/versions/27f7f8832dfa_add_pre_member_group.py
@@ -1,4 +1,4 @@
-"""add pre member account
+"""add pre member group to config
 
 Revision ID: 27f7f8832dfa
 Revises: fb8d553a7268

--- a/pycroft/model/alembic/versions/fb8d553a7268_add_account_pattern.py
+++ b/pycroft/model/alembic/versions/fb8d553a7268_add_account_pattern.py
@@ -7,8 +7,6 @@ Create Date: 2021-04-26 22:16:41.772282
 """
 from alembic import op
 import sqlalchemy as sa
-import pycroft
-
 
 # revision identifiers, used by Alembic.
 revision = 'fb8d553a7268'

--- a/pycroft/model/config.py
+++ b/pycroft/model/config.py
@@ -37,6 +37,10 @@ class Config(IntegerIdModel):
         Integer, ForeignKey(PropertyGroup.id), nullable=False)
     treasurer_group = relationship(
         PropertyGroup, foreign_keys=[treasurer_group_id])
+    pre_member_group_id = Column(
+        Integer, ForeignKey(PropertyGroup.id), nullable=False)
+    pre_member_group = relationship(
+        PropertyGroup, foreign_keys=[pre_member_group_id])
     traffic_limit_exceeded_group_id = Column(Integer, ForeignKey(PropertyGroup.id),
                             nullable=False)
     traffic_limit_exceeded_group = relationship(PropertyGroup,

--- a/tests/factories/config.py
+++ b/tests/factories/config.py
@@ -31,6 +31,7 @@ class ConfigFactory(BaseFactory):
     blocked_group = SubFactory(PropertyGroupFactory)
     caretaker_group = SubFactory(PropertyGroupFactory)
     treasurer_group = SubFactory(PropertyGroupFactory)
+    pre_member_group = SubFactory(PropertyGroupFactory)
 
     # `Account`s
     membership_fee_account = SubFactory(AccountFactory)


### PR DESCRIPTION
Add a new user to a `pre-member` group, if the move-in date is in the future.

Required, so that users that will be a member in the future are able to login on SIPA before their membership starts.