### PR TITLE
Introduce an Architecture Decision Record

### DIFF
--- a/doc/arch/adr-001.rst
+++ b/doc/arch/adr-001.rst
@@ -1,0 +1,78 @@
+ADR001
+======
+
+:Number: 001
+:Title: Use jQuery in typescript modules exclusively
+:Author: Lukas Juhrich
+:Created: 2021-06-20
+:Status: Proposed
+
+.. contents:: Table of Contents
+
+Context
+-------
+There's multiple ways to interact with our HTML output using Javascript:
+
+#. Add inline Javascript in e.g. a ``{% page_script %}`` block
+#. Add an ECMAscript (ES) or typescript (TS) module,
+   configure webpack to export it as a chunk,
+   and reference it in the relevant HTML pages
+#. Add an ES/TS module, and import it in the ``main`` chunk.
+
+The important differences between option one and the other two are
+
+- In inline JS, one cannot use an
+  `ES2015 import <https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/import>`_
+  to use arbitrary libraries.
+  However, this can indirectly be achieved by using
+  the `expose-loader <https://github.com/webpack-contrib/expose-loader>`_
+  or the `ProvidePlugin <https://webpack.js.org/plugins/provide-plugin/>`_
+  in webpack's config to expose certain symbols as ``window.foo``.
+- In a separate module, we're able to use typescript.
+- A separate module has to undergo the webpack toolchain, whereas inline JS is “cheap” in that respect.
+
+Prior to this decision, we did a cleanup of the webpack rules,
+which replaced brute-force ``ProvidePlugin`` invocations
+
+- by specific import injections via ``imports-loader``
+- or by ``window`` attribute expositions using ``expose-loader``.
+
+This is mainly motivated by a comment of Sebastian Schrader stating that blindly
+providing things via ``ProvidePlugin`` can have detrimental effects on
+`tree shaking <https://webpack.js.org/guides/tree-shaking/>`_
+because webpack cannot make any strong assumptions anymore about who the dependents of an exposed symbol are.
+
+Also, most uses of these plugins can be considered workarounds for a deficiency,
+since most inter-module dependencies should be realized by proper module ``import`` s and ``export`` s.
+
+In light of this workaround, two instances of inline JS broke
+because jQuery's ``$`` symbol was not accessible anymore.
+In one instance, this was actually unavoidable, because ``bootstrapTable``
+is only accessible as a jQuery extension function, a fact which will
+`remain that way <https://github.com/wenzhixin/bootstrap-table/issues/4796#issuecomment-578567848>`_
+in the forseeable future.
+
+
+Decision
+--------
+#. New JS code that requires jQuery or jQuery extension functions shall occur in TS modules.
+#. No jQuery invocations shall exist in inline JS.
+#. Current jQuery invocations that exist in ES modules shall be replaced by pure-ES alternatives wherever possible,
+   or turned into TS code.
+   This does not need to happen retrospectively, but at the latest whenever these invocations are next modified.
+
+
+Consequences
+------------
+- The ``providePlugin`` section in the webpack config does not have to be reinstantiated.
+- The aforementioned, broken inline-JS took significantly more effort to fix:
+  We had to create a new typescript module, and to make the ``$().bootstrap`` invocations compile,
+  and we had to add declaration files (``.d.ts``), declaring the signature of ``bootstrapTable('refresh', params)``.
+- As a consequence, code completion and documentation lookups in JS files are now aware of this extension function,
+  and can provide documentation and type hints.
+- Every new usage of ``bootstrapTable`` functionality now requires adding type declarations,
+  which is a slight increase in effort as opposed to just reading the API docs.
+- From a contribbutor who is not too acquainted with TS syntax, this demands a few minutes more in time investment.
+  This cost however does not scale linearly, as with more functions declared,
+  more examples to imitate exist directly in the codebase.
+- Frontend developers are forced to read up on modern solutions to the problems jQuery once tried to solve.

--- a/doc/arch/adr-XXX.rst
+++ b/doc/arch/adr-XXX.rst
@@ -1,0 +1,29 @@
+ADRXXX
+======
+
+:Number: XXX
+:Title: Short nouns summarizing the decision.
+:Author: Max Mustermann
+:Created: 2021-06-20
+:Status: Approved
+
+.. contents:: Table of Contents
+
+Context
+-------
+Benefit / Purpose of the decision, and what the technical context was that lead to it.
+Should be written in a way that can be understood by any team member three years later.
+
+Decision
+--------
+Things of the following kind:
+
+- Instead of doing X like we always did, we're now going to do Y.
+- We're starting to do X.
+- We're not doing Y anymore because reason X which lead to Y is obsolete.
+
+Consequences
+------------
+Immediate changes are X, to consolidate all things to Y requires such and such effort.
+Long term effects are Z.
+In the dailly work of a developer working on C, instead of just doing D, D' has to be done as well.

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -94,7 +94,7 @@ pygments_style = 'sphinx'
 
 # The theme to use for HTML and HTML Help pages.  See the documentation for
 # a list of builtin themes.
-html_theme = 'default'
+html_theme = 'alabaster'
 
 # Theme options are theme-specific and customize the look and feel of a theme
 # further.  For a list of options available for each theme, see the

--- a/doc/index.rst
+++ b/doc/index.rst
@@ -18,3 +18,11 @@ Indices and tables
 * :ref:`modindex`
 * :ref:`search`
 
+Architecture decision records
+=============================
+
+.. toctree::
+   :maxdepth: 1
+   :glob:
+
+   arch/*

--- a/doc/index.rst
+++ b/doc/index.rst
@@ -25,4 +25,5 @@ Architecture decision records
    :maxdepth: 1
    :glob:
 
+   ADR001 – Use jQuery in typescript modules exclusively <arch/adr-001.rst>
    arch/*

--- a/requirements.dev.txt
+++ b/requirements.dev.txt
@@ -4,3 +4,5 @@ pydot~=1.4.1
 pytest~=6.2.1
 git+git://github.com/lukasjuhrich/sqlalchemy_schemadisplay.git@master#egg=sqlalchemy-schemadisplay
 pytest-flask~=1.2.0
+sphinx~=4.0.2
+sphinx-autobuild~=2021.3.14


### PR DESCRIPTION
In my six years of contribution, I've often witnessed people having great ideas of how to structure things, which became forgotten more quickly than they became known by the devs working on the relevant code.

This is an example of how I would (sometimes) like to persist a decision I made about our internal architecture ([pre-render for the lazy](http://agdsn.me/~lukasjuhrich/pycroft/arch/adr-001.html)).

The purpose of these ADRs would not be to add bureaucracy to the way make our decisions (I think the process is fine-as-is – in particular I don't want every decision to have to be “vetted” by a PR reviewer), but simply to make any decisions that we _already make_ visible.
This causes
1. …decisions and their rationale to be as transparent in six months as they were at the time of their conception
2. …the „strength“ of the decision to be more visible, because the reasoning has to be clearly lined out and verbalized.

An ADR may also just be a very short notice that „To achieve X I decided Y because that's clearly the reasonable thing to do in llight of Z“.

---
In this example, since the topic is a bit complex, the ADR turned out to be a lot; and in order to avoid factual inaccuracies I'd like specific feedback and approval from @sebschrader.

**Further notes**
See https://cognitect.com/blog/2011/11/15/documenting-architecture-decisions.