### PR TITLE
Add query for archivable users and display them in table

### DIFF
--- a/doc/arch/adr-003.rst
+++ b/doc/arch/adr-003.rst
@@ -1,0 +1,59 @@
+ADR003
+======
+
+:Number: 003
+:Title: Use ``.table_valued`` wrapper for table valued sql functions
+:Author: Lukas Juhrich
+:Created: 2021-07-14
+:Status: Postulated
+
+.. contents:: Table of Contents
+
+Context
+-------
+The currently used way of using table valued functions is to use ``func.function_name``
+and then refering to the columns it returns via ``literal_column('column_name')``.
+Typos in the column name go undetected, because a priori, sqlalchemy does not know the schema of the table returned.
+This can be done by calling ``.table_valued(*cols, name)`` on the function expression.
+The result is a ``TableValuedAlias``, which provides all the attributes of a proper selectable,
+in particular one can reference its columns via ``.c.column_name`` or ``.columns.column_name``.
+
+For instance, the ``evaluate_properties`` function may be called this way:
+
+.. code-block:: python
+
+   tv = func.evaluate_properties(when=None)\
+       .table_valued('user_id', 'property_name', 'denied', name=name)
+
+   stmt = select(tv).where(tv.c.denied == False)
+
+This should be the default approach, as incorrect usages such as ``tv.c.deneid``
+will be detected at ``compile time``.
+
+The only occurrences of tabble valued functions are
+- ``evaluate_properties``
+- ``traffic_history_function``
+
+The last case can be ignored becase the function is only used once in the subsequent view definition.
+
+Decision
+--------
+- Every SQL function we manually define and use in python code shall have a corresponding function
+  of the following signature:
+
+  .. code-block:: python
+
+     def function_name(*args, name: str) -> TableValuedAlias:
+         return func.function_name(*args)\
+             .table_valued(*columns, name=name)
+
+- Every usage of such a SQL function shall use the aforementioned function
+  and refer to columns via the ``.c`` property instead of via ``literal_column``.
+
+
+Consequences
+------------
+- The current usages must be consolidated to fit this pattern.
+- Future function definitions need to write three lines more code.
+- Future function invocations may need to introduce a variable for each function invocation
+  in order to reference its columns, possibly causing slightly more comprehensive queries.

--- a/doc/index.rst
+++ b/doc/index.rst
@@ -27,4 +27,5 @@ Architecture decision records
 
    ADR001 – Use jQuery in typescript modules exclusively <arch/adr-001.rst>
    ADR002 - Continue using pickle as default serializer <arch/adr-002.rst>
+   ADR003 - Use ``.table_valued`` wrapper for table valued sql functions <arch/adr-003.rst>
    arch/*

--- a/pycroft/helpers/interval.py
+++ b/pycroft/helpers/interval.py
@@ -779,8 +779,11 @@ class IntervalModel:
         :return:
         """
         if when is None:
-            now = session.utcnow()
-            when = single(now)
+            # use `current_timestamp()`
+            return and_(
+                or_(cls.begins_at == null(), cls.begins_at <= func.current_timestamp()),
+                or_(cls.ends_at == null(), func.current_timestamp() <= cls.ends_at)
+            ).label('active')
 
         return and_(
             or_(cls.begins_at == null(), literal(when.end) == null(),

--- a/pycroft/lib/finance.py
+++ b/pycroft/lib/finance.py
@@ -35,7 +35,7 @@ from pycroft.model.finance import (
 from pycroft.helpers.interval import (
     closed, single, Bound, Interval, IntervalSet, UnboundedInterval, closedopen)
 from pycroft.model.functions import sign, least
-from pycroft.model.property import CurrentProperty
+from pycroft.model.property import CurrentProperty, evaluate_properties
 from pycroft.model.session import with_transaction
 from pycroft.model.types import Money
 from pycroft.model.user import User, Membership, RoomHistoryEntry
@@ -211,10 +211,8 @@ def users_eligible_for_fee_query(membership_fee):
     begin_tstz = datetime.combine(membership_fee.begins_on, time_min())
     end_tstz = datetime.combine(membership_fee.ends_on, time_max())
 
-    fee_prop_beginning = func.evaluate_properties(properties_beginning_timestamp) \
-        .table_valued('user_id', 'property_name', 'denied', name='fee_prop_beg')
-    fee_prop_end = func.evaluate_properties(properties_end_timestamp) \
-        .table_valued('user_id', 'property_name', 'denied', name='fee_prop_end')
+    fee_prop_beginning = evaluate_properties(properties_beginning_timestamp, name='fee_prop_beg')
+    fee_prop_end = evaluate_properties(properties_end_timestamp, name='fee_prop_end')
 
     return (future.select(User.id.label('id'),
                      User.name.label('name'),

--- a/pycroft/lib/user_deletion.py
+++ b/pycroft/lib/user_deletion.py
@@ -61,8 +61,9 @@ def get_archivable_members() -> list[ArchivableMemberInfo]:
         .options(joinedload(User.hosts), joinedload(User.current_memberships),
                  joinedload(User.account))
     )
-
-    return session.execute(stmt).all()
+    # The default dedupe strategy for the `mem_id` and `mem_end` columns is `id` instead of `hash`.
+    # See sqlalchemy#6769
+    return session.execute(stmt).unique(lambda row: row).all()
 
 
 def get_invalidated_archive_memberships() -> list[Membership]:

--- a/pycroft/lib/user_deletion.py
+++ b/pycroft/lib/user_deletion.py
@@ -59,7 +59,8 @@ def get_archivable_members() -> list[ArchivableMemberInfo]:
         .filter(last_mem.c.mem_end < current_timestamp() - timedelta(days=14))
         .order_by(last_mem.c.mem_end)
         .options(joinedload(User.hosts), joinedload(User.current_memberships),
-                 joinedload(User.account), joinedload(User.room))
+                 joinedload(User.account), joinedload(User.room),
+                 joinedload(User.current_properties_maybe_denied))
     )
     # The default dedupe strategy for the `mem_id` and `mem_end` columns is `id` instead of `hash`.
     # See sqlalchemy#6769

--- a/pycroft/lib/user_deletion.py
+++ b/pycroft/lib/user_deletion.py
@@ -54,7 +54,7 @@ def get_archivable_members() -> list[ArchivableMemberInfo]:
                    not_(CurrentProperty.denied)),
               isouter=True)
         # …and use that to filter out the `noarchive` occurrences.
-        .filter(CurrentProperty.property_name.is_not(None))
+        .filter(CurrentProperty.property_name.is_(None))
         .join(User, User.id == last_mem.c.user_id)
         .filter(last_mem.c.mem_end < current_timestamp() - timedelta(days=14))
         .order_by(last_mem.c.mem_end)

--- a/pycroft/lib/user_deletion.py
+++ b/pycroft/lib/user_deletion.py
@@ -24,7 +24,7 @@ def get_archivable_members() -> list[ArchivableMemberInfo]:
 
     Selected are those users
     - whose last membership in the member_group ended two weeks in the past,
-    - excluding users who currently have the `noarchive` property.
+    - excluding users who currently have the `do-not-archive` property.
     """
     # see FunctionElement.over
     window_args = {'partition_by': User.id, 'order_by': nulls_last(Membership.ends_at),
@@ -47,13 +47,13 @@ def get_archivable_members() -> list[ArchivableMemberInfo]:
             last_mem.c.mem_end,
         )
         .select_from(last_mem)
-        # Join the granted `noarchive` property, if existent
+        # Join the granted `do-not-archive` property, if existent
         .join(CurrentProperty,
               and_(last_mem.c.user_id == CurrentProperty.user_id,
-                   CurrentProperty.property_name == 'noarchive',
+                   CurrentProperty.property_name == 'do-not-archive',
                    not_(CurrentProperty.denied)),
               isouter=True)
-        # …and use that to filter out the `noarchive` occurrences.
+        # …and use that to filter out the `do-not-archive` occurrences.
         .filter(CurrentProperty.property_name.is_(None))
         .join(User, User.id == last_mem.c.user_id)
         .filter(last_mem.c.mem_end < current_timestamp() - timedelta(days=14))

--- a/pycroft/lib/user_deletion.py
+++ b/pycroft/lib/user_deletion.py
@@ -1,0 +1,63 @@
+from datetime import timedelta
+
+from sqlalchemy import func, nulls_last
+from sqlalchemy.engine import Row
+from sqlalchemy.future import select
+from sqlalchemy.sql.elements import and_, not_
+from sqlalchemy.sql.functions import current_timestamp
+
+from pycroft import config, Config
+from pycroft.model.property import CurrentProperty
+from pycroft.model.session import session
+from pycroft.model.user import User, Membership
+
+
+def get_archivable_members() -> list[Row]:
+    """Return all the users that qualify for being archived right now.
+
+    Selected are those users
+    - whose last membership in the member_group ended two weeks in the past,
+    - excluding users who currently have the `noarchive` property.
+    """
+    # see FunctionElement.over
+    window_args = {'partition_by': User.id, 'order_by': nulls_last(Membership.ends_at),
+                   'rows': (None, None)}
+    last_mem = (
+        select(
+            User.id.label('user_id'),
+            func.last_value(Membership.id).over(**window_args).label('mem_id'),
+            func.last_value(Membership.ends_at).over(**window_args).label('mem_end'),
+        )
+        .select_from(User)
+        .distinct()
+        .join(Membership)
+        .join(Config, Config.member_group_id == Membership.group_id)
+    ).cte('last_mem')
+    stmt = (
+        select(
+            User,
+            last_mem.c.mem_id,
+            last_mem.c.mem_end,
+            CurrentProperty.property_name.is_not(None).label('noarchive')
+        )
+        .select_from(last_mem)
+        .join(CurrentProperty,
+              and_(last_mem.c.user_id == CurrentProperty.user_id,
+                   CurrentProperty.property_name == 'noarchive',
+                   not_(CurrentProperty.denied)),
+              isouter=True)
+        .join(User, User.id == last_mem.c.user_id)
+        .filter(last_mem.c.mem_end < current_timestamp() - timedelta(days=14))
+        .order_by(last_mem.c.mem_end)
+    )
+
+    return session.execute(stmt).all()
+
+
+def get_invalidated_archive_memberships() -> list[Membership]:
+    """Get all memberships in `to_be_archived` of users who have an active `do-not-archive` property.
+
+    This can happen if archivability is detected, and later the user becomes a member again,
+    or if for some reason the user shall not be archived.
+    """
+    pass

--- a/pycroft/lib/user_deletion.py
+++ b/pycroft/lib/user_deletion.py
@@ -1,7 +1,7 @@
-from datetime import timedelta
+from datetime import timedelta, datetime
+from typing import Protocol
 
 from sqlalchemy import func, nulls_last
-from sqlalchemy.engine import Row
 from sqlalchemy.future import select
 from sqlalchemy.sql.elements import and_, not_
 from sqlalchemy.sql.functions import current_timestamp
@@ -12,7 +12,13 @@ from pycroft.model.session import session
 from pycroft.model.user import User, Membership
 
 
-def get_archivable_members() -> list[Row]:
+class ArchivableMemberInfo(Protocol):
+    User: User
+    mem_id: int
+    mem_end: datetime
+
+
+def get_archivable_members() -> list[ArchivableMemberInfo]:
     """Return all the users that qualify for being archived right now.
 
     Selected are those users

--- a/pycroft/lib/user_deletion.py
+++ b/pycroft/lib/user_deletion.py
@@ -3,10 +3,11 @@ from typing import Protocol
 
 from sqlalchemy import func, nulls_last
 from sqlalchemy.future import select
+from sqlalchemy.orm import joinedload
 from sqlalchemy.sql.elements import and_, not_
 from sqlalchemy.sql.functions import current_timestamp
 
-from pycroft import config, Config
+from pycroft import Config
 from pycroft.model.property import CurrentProperty
 from pycroft.model.session import session
 from pycroft.model.user import User, Membership
@@ -57,6 +58,8 @@ def get_archivable_members() -> list[ArchivableMemberInfo]:
         .join(User, User.id == last_mem.c.user_id)
         .filter(last_mem.c.mem_end < current_timestamp() - timedelta(days=14))
         .order_by(last_mem.c.mem_end)
+        .options(joinedload(User.hosts), joinedload(User.current_memberships),
+                 joinedload(User.account))
     )
 
     return session.execute(stmt).all()

--- a/pycroft/lib/user_deletion.py
+++ b/pycroft/lib/user_deletion.py
@@ -44,14 +44,16 @@ def get_archivable_members() -> list[ArchivableMemberInfo]:
             User,
             last_mem.c.mem_id,
             last_mem.c.mem_end,
-            CurrentProperty.property_name.is_not(None).label('noarchive')
         )
         .select_from(last_mem)
+        # Join the granted `noarchive` property, if existent
         .join(CurrentProperty,
               and_(last_mem.c.user_id == CurrentProperty.user_id,
                    CurrentProperty.property_name == 'noarchive',
                    not_(CurrentProperty.denied)),
               isouter=True)
+        # …and use that to filter out the `noarchive` occurrences.
+        .filter(CurrentProperty.property_name.is_not(None))
         .join(User, User.id == last_mem.c.user_id)
         .filter(last_mem.c.mem_end < current_timestamp() - timedelta(days=14))
         .order_by(last_mem.c.mem_end)

--- a/pycroft/lib/user_deletion.py
+++ b/pycroft/lib/user_deletion.py
@@ -59,7 +59,7 @@ def get_archivable_members() -> list[ArchivableMemberInfo]:
         .filter(last_mem.c.mem_end < current_timestamp() - timedelta(days=14))
         .order_by(last_mem.c.mem_end)
         .options(joinedload(User.hosts), joinedload(User.current_memberships),
-                 joinedload(User.account))
+                 joinedload(User.account), joinedload(User.room))
     )
     # The default dedupe strategy for the `mem_id` and `mem_end` columns is `id` instead of `hash`.
     # See sqlalchemy#6769

--- a/pycroft/model/base.py
+++ b/pycroft/model/base.py
@@ -40,7 +40,7 @@ class ModelBase(object):
     """Base class for all database models."""
 
     @declared_attr
-    def __tablename__(cls):
+    def __tablename__(cls) -> str:
         """Autogenerate the tablename for the mapped objects."""
         return cls._to_snake_case(cls.__name__)
 

--- a/pycroft/model/config.py
+++ b/pycroft/model/config.py
@@ -10,52 +10,52 @@ from pycroft.model.user import PropertyGroup
 
 
 class Config(IntegerIdModel):
-    member_group_id = Column(
+    member_group_id: int = Column(
         Integer, ForeignKey(PropertyGroup.id), nullable=False)
-    member_group = relationship(PropertyGroup, foreign_keys=[member_group_id])
-    network_access_group_id = Column(
+    member_group: PropertyGroup = relationship(PropertyGroup, foreign_keys=[member_group_id])
+    network_access_group_id: int = Column(
         Integer, ForeignKey(PropertyGroup.id), nullable=False)
-    network_access_group = relationship(
+    network_access_group: PropertyGroup = relationship(
         PropertyGroup, foreign_keys=[network_access_group_id])
-    violation_group_id = Column(
+    violation_group_id: int = Column(
         Integer, ForeignKey(PropertyGroup.id), nullable=False)
-    violation_group = relationship(
+    violation_group: PropertyGroup = relationship(
         PropertyGroup, foreign_keys=[violation_group_id])
-    external_group_id = Column(
+    external_group_id: int = Column(
         Integer, ForeignKey(PropertyGroup.id), nullable=False)
-    external_group = relationship(
+    external_group: PropertyGroup = relationship(
         PropertyGroup, foreign_keys=[external_group_id])
-    blocked_group_id = Column(
+    blocked_group_id: int = Column(
         Integer, ForeignKey(PropertyGroup.id), nullable=False)
-    blocked_group = relationship(
+    blocked_group: PropertyGroup = relationship(
         PropertyGroup, foreign_keys=[blocked_group_id])
-    caretaker_group_id = Column(
+    caretaker_group_id: int = Column(
         Integer, ForeignKey(PropertyGroup.id), nullable=False)
-    caretaker_group = relationship(
+    caretaker_group: PropertyGroup = relationship(
         PropertyGroup, foreign_keys=[caretaker_group_id])
-    treasurer_group_id = Column(
+    treasurer_group_id: int = Column(
         Integer, ForeignKey(PropertyGroup.id), nullable=False)
-    treasurer_group = relationship(
+    treasurer_group: PropertyGroup = relationship(
         PropertyGroup, foreign_keys=[treasurer_group_id])
-    pre_member_group_id = Column(
+    pre_member_group_id: int = Column(
         Integer, ForeignKey(PropertyGroup.id), nullable=False)
-    pre_member_group = relationship(
+    pre_member_group: PropertyGroup = relationship(
         PropertyGroup, foreign_keys=[pre_member_group_id])
-    traffic_limit_exceeded_group_id = Column(Integer, ForeignKey(PropertyGroup.id),
+    traffic_limit_exceeded_group_id: int = Column(Integer, ForeignKey(PropertyGroup.id),
                             nullable=False)
-    traffic_limit_exceeded_group = relationship(PropertyGroup,
+    traffic_limit_exceeded_group: PropertyGroup = relationship(PropertyGroup,
                                                 foreign_keys=[traffic_limit_exceeded_group_id])
-    payment_in_default_group_id = Column(Integer, ForeignKey(PropertyGroup.id),
+    payment_in_default_group_id: int = Column(Integer, ForeignKey(PropertyGroup.id),
                             nullable=False)
-    payment_in_default_group = relationship(PropertyGroup, foreign_keys=[payment_in_default_group_id])
-    membership_fee_account_id = Column(
+    payment_in_default_group: PropertyGroup = relationship(PropertyGroup, foreign_keys=[payment_in_default_group_id])
+    membership_fee_account_id: int = Column(
         Integer, ForeignKey(Account.id), nullable=False)
-    membership_fee_account = relationship(
+    membership_fee_account: Account = relationship(
         Account, foreign_keys=[membership_fee_account_id])
-    membership_fee_bank_account_id = Column(
+    membership_fee_bank_account_id: int = Column(
         Integer, ForeignKey(BankAccount.id), nullable=False)
-    membership_fee_bank_account = relationship(
+    membership_fee_bank_account: BankAccount = relationship(
         BankAccount, foreign_keys=[membership_fee_bank_account_id])
-    fints_product_id = Column(String, nullable=True)
+    fints_product_id: str = Column(String, nullable=True)
 
     __table_args__ = (CheckConstraint("id = 1"),)

--- a/pycroft/model/user.py
+++ b/pycroft/model/user.py
@@ -236,6 +236,7 @@ class User(ModelBase, BaseUser, UserMixin):
         'CurrentProperty',
         primaryjoin='and_(User.id == foreign(CurrentProperty.user_id),'
                     '~CurrentProperty.denied)',
+        order_by='CurrentProperty.property_name',
         viewonly=True
     )
     #: This is a relationship to the `current_property` view ignoring the
@@ -243,6 +244,7 @@ class User(ModelBase, BaseUser, UserMixin):
     current_properties_maybe_denied = relationship(
         'CurrentProperty',
         primaryjoin='User.id == foreign(CurrentProperty.user_id)',
+        order_by='CurrentProperty.property_name',
         viewonly=True
     )
 

--- a/pycroft/model/user.py
+++ b/pycroft/model/user.py
@@ -282,6 +282,12 @@ class User(ModelBase, BaseUser, UserMixin):
         else:
             return user if user.check_password(plaintext_password) else None
 
+    current_memberships = relationship(
+        'Membership',
+        primaryjoin='and_(Membership.user_id==User.id, Membership.active())',
+        viewonly=True
+    )
+
     @hybrid_method
     def active_memberships(self, when: Optional[Interval] = None) -> List[Membership]:
         if when is None:

--- a/scripts/server_run.py
+++ b/scripts/server_run.py
@@ -69,7 +69,7 @@ def prepare_server(args) -> Tuple[PycroftFlask, Callable]:
             if time_taken > 0.5:
                 app.logger.warning(
                     "Response took %s seconds for request %s",
-                    request.full_path, time_taken,
+                    time_taken, request.full_path,
                 )
 
     connection, engine = try_create_connection(connection_string, wait_for_db, app.logger,

--- a/tests/model/test_user.py
+++ b/tests/model/test_user.py
@@ -160,8 +160,12 @@ class TestActiveHybridMethods(FactoryDataTestBase):
 
     def test_active_memberships(self):
         assert self.user.active_memberships() == []
+        assert self.user.current_memberships == []
+
         m = self.add_membership(self.property_group)
         assert self.user.active_memberships() == [m]
+        assert self.user.current_memberships == [m]
+
         when = single(session.utcnow() - timedelta(hours=1))
         assert self.user.active_memberships(when) == []
         when = single(session.utcnow() + timedelta(hours=1))

--- a/web/blueprints/user/__init__.py
+++ b/web/blueprints/user/__init__.py
@@ -1272,3 +1272,10 @@ def resend_confirmation_mail():
         session.session.commit()
 
         return redirect(return_url)
+
+
+@nav.navigate('Archivable users')
+@bp.route('/archivable_users')
+def archivable_users():
+    from pycroft.lib.user_deletion import get_archivable_members
+    return render_template('user/archivable_users.html', rows=get_archivable_members())

--- a/web/blueprints/user/__init__.py
+++ b/web/blueprints/user/__init__.py
@@ -1253,7 +1253,7 @@ def resend_confirmation_mail():
     user_id = request.args.get('user_id', type=int)
     is_prm = request.args.get('is_prm', type=bool, default=False)
 
-    user: BaseUser = None
+    user: BaseUser
 
     if is_prm:
         user = get_pre_member_or_404(user_id)

--- a/web/blueprints/user/__init__.py
+++ b/web/blueprints/user/__init__.py
@@ -1292,6 +1292,10 @@ def archivable_users_json():
                 title=info.User.name,
                 href=url_for('user.user_show', user_id=info.User.id)
             ),
+            room_shortname=info.User.room and T.room_shortname.value(
+                title=info.User.room.short_name,
+                href=url_for('facilities.room_show', room_id=info.User.room.id)
+            ),
             num_hosts=len(info.User.hosts),
             # TODO better: `DateColumn.value`
             end_of_membership=datetime_format(info.mem_end)

--- a/web/blueprints/user/__init__.py
+++ b/web/blueprints/user/__init__.py
@@ -1300,6 +1300,6 @@ def archivable_users_json():
                                         for p in info.User.current_properties_maybe_denied),
             num_hosts=len(info.User.hosts),
             # TODO better: `DateColumn.value`
-            end_of_membership=datetime_format(info.mem_end)
+            end_of_membership=date_format(info.mem_end.date())
         ) for info in get_archivable_members()
     ]}

--- a/web/blueprints/user/__init__.py
+++ b/web/blueprints/user/__init__.py
@@ -1296,6 +1296,8 @@ def archivable_users_json():
                 title=info.User.room.short_name,
                 href=url_for('facilities.room_show', room_id=info.User.room.id)
             ),
+            current_properties=" ".join(("~" if p.denied else "") + p.property_name
+                                        for p in info.User.current_properties_maybe_denied),
             num_hosts=len(info.User.hosts),
             # TODO better: `DateColumn.value`
             end_of_membership=datetime_format(info.mem_end)

--- a/web/blueprints/user/tables.py
+++ b/web/blueprints/user/tables.py
@@ -110,7 +110,7 @@ class PreMemberTable(BootstrapTable):
 
 class ArchivableMembersTable(RefreshableTableMixin, BootstrapTable):
     class Meta:
-        table_args = {'data-escape': 'false'}
+        table_args = {'data-escape': 'false', 'data-sort-stable': True}
 
     id = Column("#")
     user = LinkColumn("Mitglied")

--- a/web/blueprints/user/tables.py
+++ b/web/blueprints/user/tables.py
@@ -109,10 +109,13 @@ class PreMemberTable(BootstrapTable):
 
 
 class ArchivableMembersTable(RefreshableTableMixin, BootstrapTable):
-    id = Column("ID")
+    class Meta:
+        table_args = {'data-escape': 'false'}
+
+    id = Column("#")
     user = LinkColumn("Mitglied")
-    room_shortname = LinkColumn("Raum")
-    num_hosts = Column("#Hosts")
+    room_shortname = LinkColumn("<i class=\"fas fa-home\"></i>")
+    num_hosts = Column("<i class=\"fas fa-laptop\"></i>")
     current_properties = Column("Props", formatter="table.propertiesFormatter")
     end_of_membership = DateColumn("EOM")
 

--- a/web/blueprints/user/tables.py
+++ b/web/blueprints/user/tables.py
@@ -1,3 +1,5 @@
+import typing
+
 from flask import url_for
 
 from bs_table_py.table import BootstrapTable, Column, \
@@ -104,3 +106,15 @@ class PreMemberTable(BootstrapTable):
         table_args = {
             'data-row-style': 'table.membershipRequestRowFormatter',
         }
+
+
+class ArchivableMembersTable(RefreshableTableMixin, BootstrapTable):
+    id = Column("ID")
+    user = LinkColumn("Mitglied")
+    num_hosts = Column("#Hosts")
+    end_of_membership = DateColumn("EOM")
+
+    if typing.TYPE_CHECKING:
+        @classmethod
+        def row(cls, id: int, user: dict, num_hosts: int, end_of_membership: dict) -> dict: ...
+

--- a/web/blueprints/user/tables.py
+++ b/web/blueprints/user/tables.py
@@ -113,10 +113,12 @@ class ArchivableMembersTable(RefreshableTableMixin, BootstrapTable):
     user = LinkColumn("Mitglied")
     room_shortname = LinkColumn("Raum")
     num_hosts = Column("#Hosts")
+    current_properties = Column("Props", formatter="table.propertiesFormatter")
     end_of_membership = DateColumn("EOM")
 
     if typing.TYPE_CHECKING:
         @classmethod
         def row(cls, id: int, user: dict, room_shortname: dict,
+                current_properties: str,
                 num_hosts: int, end_of_membership: dict) -> dict: ...
 

--- a/web/blueprints/user/tables.py
+++ b/web/blueprints/user/tables.py
@@ -111,10 +111,12 @@ class PreMemberTable(BootstrapTable):
 class ArchivableMembersTable(RefreshableTableMixin, BootstrapTable):
     id = Column("ID")
     user = LinkColumn("Mitglied")
+    room_shortname = LinkColumn("Raum")
     num_hosts = Column("#Hosts")
     end_of_membership = DateColumn("EOM")
 
     if typing.TYPE_CHECKING:
         @classmethod
-        def row(cls, id: int, user: dict, num_hosts: int, end_of_membership: dict) -> dict: ...
+        def row(cls, id: int, user: dict, room_shortname: dict,
+                num_hosts: int, end_of_membership: dict) -> dict: ...
 

--- a/web/resources/js/table.js
+++ b/web/resources/js/table.js
@@ -527,18 +527,13 @@ export function taskDetailFormatter(index, row, element){
     rowStyle for the task table, representing the status
 */
 export function taskRowFormatter(row){
-    let cssclass = "";
-
-    if(row.status == "OPEN"){
-        cssclass = "table-warning";
-    }else if(row.status == "EXECUTED"){
-        cssclass = "table-success";
-    }else if(row.status == "FAILED"){
-        cssclass = "table-danger";
+    const mapping = {
+        "OPEN": 'table-warning',
+        "EXECUTED": 'table-success',
+        "FAILED": 'table-danger',
     }
-
     return {
-       classes: cssclass
+        classes: mapping[row.status] || ""
     }
 }
 

--- a/web/resources/js/table.js
+++ b/web/resources/js/table.js
@@ -98,9 +98,11 @@ export function linkFormatter(value, row, index) {
 }
 linkFormatter.attributes = { sortName: 'title' };
 
+/**
+ *  Format an entry as a link or plain, depending on the value of
+ * the 'type' field.  It can either be 'plain' or 'native'.
+ */
 export function userFormatter(value, row, index) {
-    /* Format an entry as a link or plain, depending on the value of
-     * the 'type' field.  It can either be 'plain' or 'native'. */
     if (!value) {
         return;
     }

--- a/web/resources/js/table.js
+++ b/web/resources/js/table.js
@@ -568,6 +568,41 @@ export function bankAccountActivitiesDetailFormatter(index, row, element){
     return html;
 }
 
+/**
+ * Convert a property string like `~prop` into a red/green property badge.
+ * @param value: string
+ * @return string
+ */
+function propertyBadge(value) {
+    const denied = value.startsWith("~");
+    const info = denied ? {
+        "propName": value.slice(1),
+        "userPropClass": "userprop-denied",
+        "spanTitle": "Granted, aber dann denied",
+    } : {
+        "propName": value,
+        "userPropClass": "userprop-granted",
+        "spanTitle": "Granted",
+    };
+    return `
+        <span class="badge userprop ${info.userPropClass}"
+           data-property-name="${info.propName}">
+          <span title="${info.spanTitle}">${info.propName}</span>
+        </span>
+    `;
+}
+
+/**
+ * Present a string of the form `foo ~bar ~baz` as red/green property badges.
+ * @param value
+ * @param row
+ * @param index
+ */
+export function propertiesFormatter(value, row, index) {
+    if (!value) { return; }
+    return value.split(/\s+/).map(propertyBadge).join(" ");
+}
+
 
 
 /**

--- a/web/templates/user/archivable_users.html
+++ b/web/templates/user/archivable_users.html
@@ -1,0 +1,14 @@
+{#
+ Copyright (c) 2021 The Pycroft Authors. See the AUTHORS file.
+ This file is part of the Pycroft project and licensed under the terms of
+ the Apache License, Version 2.0. See the LICENSE file for details.
+#}
+{% extends "layout.html" %}
+{% block content %}
+  <ul>
+  {% for row in rows %}
+      <li>{{ row.User.login }} / {{ row.mem_end }}</li>
+  {% endfor %}
+  </ul>
+
+{% endblock %}

--- a/web/templates/user/archivable_users.html
+++ b/web/templates/user/archivable_users.html
@@ -5,10 +5,5 @@
 #}
 {% extends "layout.html" %}
 {% block content %}
-  <ul>
-  {% for row in rows %}
-      <li>{{ row.User.login }} / {{ row.mem_end }}</li>
-  {% endfor %}
-  </ul>
-
+  {{ table.render('archivable-users-table') }}
 {% endblock %}


### PR DESCRIPTION
This is a preliminary overview for which users would be marked as `to-be-archived`.

The next step would be to
1. Implement a lib function to mark these users as `to-be-archived` and filter out `to-be-archived` users in `get_archivable_members`
2. Split up this table into three tables with the same columns: 
  i. Users to-be-marked (i.e. what's returned from `get_archivable_members`)
  ii. Users who are `to-be-archived`
  iii. Users who are `to-be-archived` _and_ `do-not-archive` (i.e. invalidated memberships)
3. Implement a lib routine that actually archives the users, which fails if there are invalidated memberships

Refs #470