### PR TITLE
Icons + Improved naming for user tabs

### DIFF
--- a/pycroft/exc.py
+++ b/pycroft/exc.py
@@ -1,8 +1,6 @@
 #  Copyright (c) 2021. The Pycroft Authors. See the AUTHORS file.
 #  This file is part of the Pycroft project and licensed under the terms of
 #  the Apache License, Version 2.0. See the LICENSE file for details
-from pycroft.exc import PycroftException
 
-
-class PycroftLibException(PycroftException):
+class PycroftException(Exception):
     pass

--- a/pycroft/lib/exc.py
+++ b/pycroft/lib/exc.py
@@ -1,0 +1,6 @@
+#  Copyright (c) 2021. The Pycroft Authors. See the AUTHORS file.
+#  This file is part of the Pycroft project and licensed under the terms of
+#  the Apache License, Version 2.0. See the LICENSE file for details
+
+class PycroftLibException(Exception):
+    pass

--- a/pycroft/lib/facilities.py
+++ b/pycroft/lib/facilities.py
@@ -7,6 +7,7 @@ from sqlalchemy import func, and_, distinct, literal_column
 from sqlalchemy.orm import aliased, contains_eager, joinedload
 
 from pycroft.helpers.i18n import deferred_gettext
+from pycroft.lib.exc import PycroftLibException
 from pycroft.lib.logging import log_room_event, log_event, log_user_event
 from pycroft.model import session
 from pycroft.model.address import Address
@@ -19,7 +20,7 @@ from pycroft.model.user import User
 logger = logging.getLogger(__name__)
 
 
-class RoomAlreadyExistsException(Exception):
+class RoomAlreadyExistsException(PycroftLibException):
     pass
 
 

--- a/pycroft/lib/finance.py
+++ b/pycroft/lib/finance.py
@@ -452,7 +452,7 @@ class CSVImportError(PycroftLibException):
                 message, cause
             )
         self.cause = cause
-        super(CSVImportError, self).__init__(message)
+        super().__init__(message)
 
 
 def is_ordered(iterable, relation=operator.le):

--- a/pycroft/lib/finance.py
+++ b/pycroft/lib/finance.py
@@ -26,6 +26,7 @@ from pycroft import config, model
 from pycroft.helpers.i18n import deferred_gettext, gettext, Message
 from pycroft.helpers.date import diff_month, last_day_of_month
 from pycroft.helpers.utc import time_max, time_min
+from pycroft.lib.exc import PycroftLibException
 from pycroft.lib.logging import log_user_event, log_event
 from pycroft.lib.membership import make_member_of, remove_member_of
 from pycroft.model import session
@@ -444,8 +445,7 @@ class MT940Dialect(csv.Dialect):
     quoting = csv.QUOTE_ALL
 
 
-class CSVImportError(Exception):
-
+class CSVImportError(PycroftLibException):
     def __init__(self, message, cause=None):
         if cause is not None:
             message = gettext(u"{0}\nCaused by:\n{1}").format(

--- a/pycroft/lib/infrastructure.py
+++ b/pycroft/lib/infrastructure.py
@@ -1,5 +1,6 @@
 from ipaddr import IPAddress
 
+from pycroft.lib.exc import PycroftLibException
 from pycroft.lib.logging import log_room_event, log_event
 from pycroft.model.host import SwitchPort, Host, Switch
 from pycroft.model.port import PatchPort
@@ -7,11 +8,11 @@ from pycroft.model.session import with_transaction, session
 from pycroft.model.user import User
 
 
-class PatchPortAlreadyPatchedException(Exception):
+class PatchPortAlreadyPatchedException(PycroftLibException):
     pass
 
 
-class PatchPortAlreadyExistsException(Exception):
+class PatchPortAlreadyExistsException(PycroftLibException):
     pass
 
 

--- a/pycroft/lib/mail.py
+++ b/pycroft/lib/mail.py
@@ -14,6 +14,7 @@ import traceback
 from dataclasses import dataclass
 
 from pycroft.helpers import AutoNumber
+from pycroft.lib.exc import PycroftLibException
 
 mail_envelope_from = os.environ.get('PYCROFT_MAIL_ENVELOPE_FROM')
 mail_from = os.environ.get('PYCROFT_MAIL_FROM')
@@ -84,7 +85,7 @@ def compose_mail(mail: Mail) -> MIMEMultipart:
     return msg
 
 
-class RetryableException(Exception):
+class RetryableException(PycroftLibException):
     pass
 
 

--- a/pycroft/lib/net.py
+++ b/pycroft/lib/net.py
@@ -7,17 +7,18 @@ import sys
 
 from sqlalchemy import func, and_, cast
 
+from pycroft.lib.exc import PycroftLibException
 from pycroft.model import session
 from pycroft.model.host import IP
 from pycroft.model.net import Subnet
 from pycroft.model.types import IPAddress
 
-class SubnetFullException(Exception):
+class SubnetFullException(PycroftLibException):
     def __init__(self):
         super().__init__("Subnet full")
 
 
-class MacExistsException(Exception):
+class MacExistsException(PycroftLibException):
     def __init__(self):
         super().__init__("MAC address already exists")
 

--- a/pycroft/lib/task.py
+++ b/pycroft/lib/task.py
@@ -5,6 +5,7 @@ from typing import Mapping, TypeVar, Generic
 from marshmallow import ValidationError
 from sqlalchemy.orm import with_polymorphic
 
+from pycroft.helpers.i18n import deferred_gettext
 from pycroft.lib.logging import log_task_event
 from pycroft.model import session
 from pycroft.model.session import with_transaction
@@ -210,4 +211,8 @@ def force_execute_task(task: Task, processor: User):
     if task.status != TaskStatus.OPEN:
         raise ValueError("Cannot execute a task that is not open")
 
-    pass  # not implemented
+    get_task_implementation(task).execute(task)
+
+    log_task_event(deferred_gettext("Manually executed task {}").format(task.id).to_json(),
+                   author=processor, task=task)
+    task.status = TaskStatus.EXECUTED

--- a/pycroft/lib/task.py
+++ b/pycroft/lib/task.py
@@ -167,6 +167,10 @@ task_type_to_impl: Mapping[TaskType, type[UserTaskImpl]] = {
 }
 
 
+def get_task_implementation(task: Task) -> TaskImpl:
+    return task_type_to_impl.get(task.type)()
+
+
 @with_transaction
 def schedule_user_task(task_type, due, user, parameters: TaskParams, processor):
     if due < session.utcnow():

--- a/pycroft/lib/task.py
+++ b/pycroft/lib/task.py
@@ -213,6 +213,7 @@ def force_execute_task(task: Task, processor: User):
 
     get_task_implementation(task).execute(task)
 
+    task.due = session.utcnow()
     log_task_event(deferred_gettext("Manually executed task {}").format(task.id).to_json(),
                    author=processor, task=task)
     task.status = TaskStatus.EXECUTED

--- a/pycroft/lib/task.py
+++ b/pycroft/lib/task.py
@@ -197,7 +197,7 @@ def get_active_tasks_by_type(type):
 
 
 @with_transaction
-def cancel_task(task, processor):
+def cancel_task(task: Task, processor: User):
     if task.status != TaskStatus.OPEN:
         raise ValueError("Cannot cancel a task that is not open")
 

--- a/pycroft/lib/task.py
+++ b/pycroft/lib/task.py
@@ -207,7 +207,7 @@ def cancel_task(task: Task, processor: User):
     task.status = TaskStatus.CANCELLED
 
 
-def force_execute_task(task: Task, processor: User):
+def manually_execute_task(task: Task, processor: User):
     if task.status != TaskStatus.OPEN:
         raise ValueError("Cannot execute a task that is not open")
 

--- a/pycroft/lib/task.py
+++ b/pycroft/lib/task.py
@@ -11,6 +11,7 @@ from pycroft.model.session import with_transaction
 from pycroft.model.task import UserTask, Task, TaskType, TaskStatus
 from pycroft.model.task_serialization import UserMoveOutParams, UserMoveParams, UserMoveInParams, \
     TaskParams
+from pycroft.model.user import User
 
 TTask = TypeVar('TTask')
 TParams = TypeVar('TParams')
@@ -203,3 +204,10 @@ def cancel_task(task, processor):
     log_task_event("Cancelled task {}.".format(task.id), processor, task)
 
     task.status = TaskStatus.CANCELLED
+
+
+def force_execute_task(task: Task, processor: User):
+    if task.status != TaskStatus.OPEN:
+        raise ValueError("Cannot execute a task that is not open")
+
+    pass  # not implemented

--- a/pycroft/lib/user.py
+++ b/pycroft/lib/user.py
@@ -28,6 +28,7 @@ from pycroft.helpers.interval import closed, closedopen, single
 from pycroft.helpers.printing import generate_user_sheet as generate_pdf
 from pycroft.helpers.user import generate_random_str
 from pycroft.lib.address import get_or_create_address
+from pycroft.lib.exc import PycroftLibException
 from pycroft.lib.facilities import get_room
 from pycroft.lib.finance import user_has_paid
 from pycroft.lib.logging import log_user_event, log_event
@@ -1013,32 +1014,32 @@ def send_confirmation_email(user: BaseUser):
         email_confirm_url=mail_confirm_url.format(user.email_confirmation_key)))
 
 
-class LoginTakenException(Exception):
+class LoginTakenException(PycroftLibException):
     def __init__(self):
         super().__init__("Login already taken")
 
 
-class EmailTakenException(Exception):
+class EmailTakenException(PycroftLibException):
     def __init__(self):
         super().__init__("E-Mail address already in use")
 
 
-class UserExistsInRoomException(Exception):
+class UserExistsInRoomException(PycroftLibException):
     def __init__(self):
         super().__init__("A user with a similar name already lives in this room")
 
 
-class UserExistsException(Exception):
+class UserExistsException(PycroftLibException):
     def __init__(self):
         super().__init__("This user already exists")
 
 
-class NoTenancyForRoomException(Exception):
+class NoTenancyForRoomException(PycroftLibException):
     def __init__(self):
         super().__init__("This user has no tenancy in that room")
 
 
-class MoveInDateInvalidException(Exception):
+class MoveInDateInvalidException(PycroftLibException):
     def __init__(self):
         super().__init__("The move-in date is invalid (in the past or more than 6 months in the future)")
 

--- a/pycroft/model/finance.py
+++ b/pycroft/model/finance.py
@@ -20,7 +20,7 @@ from pycroft.helpers.interval import closed
 from pycroft.model import ddl
 from pycroft.model.types import Money, DateTimeTz
 from .base import IntegerIdModel
-
+from .exc import PycroftModelException
 
 manager = ddl.DDLManager()
 
@@ -253,7 +253,7 @@ manager.add_constraint_trigger(
 )
 
 
-class IllegalTransactionError(Exception):
+class IllegalTransactionError(PycroftModelException):
     """Indicates an attempt to persist an illegal Transaction."""
     pass
 

--- a/pycroft/model/host.py
+++ b/pycroft/model/host.py
@@ -10,6 +10,7 @@ from pycroft.helpers.i18n import gettext
 from pycroft.helpers.net import mac_regex
 
 from pycroft.model.base import ModelBase, IntegerIdModel
+from pycroft.model.exc import PycroftModelException
 from pycroft.model.facilities import Room
 from pycroft.model.net import Subnet
 from pycroft.model.user import User
@@ -51,7 +52,7 @@ class Switch(ModelBase):
 # and explain why it does not work (switches → owner=root w/o room)
 def _check_user_host_in_user_room(mapper, connection, userhost):
     if userhost.room is not userhost.owner.room:
-        raise Exception("UserHost can only be in user's room")
+        raise PycroftModelException("UserHost can only be in user's room")
 
 #event.listen(Host, "before_insert", _check_user_host_in_user_room)
 #event.listen(Host, "before_update", _check_user_host_in_user_room)
@@ -61,7 +62,7 @@ class MulticastFlagException(InvalidMACAddressException):
     message = "Multicast bit set in MAC address"
 
 
-class TypeMismatch(Exception):
+class TypeMismatch(PycroftModelException):
     pass
 
 

--- a/pycroft/model/types.py
+++ b/pycroft/model/types.py
@@ -7,6 +7,7 @@ import ipaddr
 from sqlalchemy import String, TypeDecorator, Integer, DateTime
 from sqlalchemy.dialects.postgresql import MACADDR, INET
 from pycroft.helpers.net import mac_regex
+from pycroft.model.exc import PycroftModelException
 
 
 class _IPType(TypeDecorator):
@@ -102,7 +103,7 @@ class Money(TypeDecorator):
         return Decimal(value).scaleb(-2)
 
 
-class InvalidMACAddressException(ValueError):
+class InvalidMACAddressException(PycroftModelException, ValueError):
     pass
 
 

--- a/pycroft/model/user.py
+++ b/pycroft/model/user.py
@@ -35,17 +35,18 @@ from pycroft.model import session, ddl
 from pycroft.model.address import Address, address_remove_orphans
 from pycroft.model.base import ModelBase, IntegerIdModel
 from pycroft.helpers.interval import IntervalModel
+from pycroft.model.exc import PycroftModelException
 from pycroft.model.facilities import Room
 from pycroft.model.types import DateTimeTz
 
 manager = ddl.DDLManager()
 
 
-class IllegalLoginError(ValueError):
+class IllegalLoginError(PycroftModelException, ValueError):
     pass
 
 
-class IllegalEmailError(ValueError):
+class IllegalEmailError(PycroftModelException, ValueError):
     pass
 
 

--- a/pycroft/task.py
+++ b/pycroft/task.py
@@ -18,7 +18,7 @@ from pycroft.lib.finance import get_negative_members
 from pycroft.lib.logging import log_task_event
 from pycroft.lib.mail import send_mails, Mail, RetryableException, TaskFailedTemplate, \
     MemberNegativeBalance
-from pycroft.lib.task import task_type_to_impl
+from pycroft.lib.task import get_task_implementation
 from pycroft.model import session
 from pycroft.model.finance import BankAccountActivity
 from pycroft.model.session import with_transaction
@@ -84,7 +84,7 @@ def execute_scheduled_tasks():
     for task in tasks:
         repair_session()
 
-        task_impl = task_type_to_impl.get(task.type)()
+        task_impl = get_task_implementation(task)
 
         try:
             task_impl.execute(task)

--- a/tests/factories/__init__.py
+++ b/tests/factories/__init__.py
@@ -12,3 +12,4 @@ from .property import PropertyGroupFactory, MembershipFactory, AdminPropertyGrou
 from .user import UserFactory, UserWithoutRoomFactory, UserWithHostFactory, UnixAccountFactory
 from .traffic import TrafficDataFactory, TrafficVolumeFactory, TrafficVolumeLastWeekFactory
 from .log import RoomLogEntryFactory, UserLogEntryFactory
+from .task import UserTaskFactory

--- a/tests/lib/test_task.py
+++ b/tests/lib/test_task.py
@@ -4,6 +4,7 @@
 import datetime
 
 from pycroft.lib.task import cancel_task, force_execute_task
+from pycroft.model import session
 from pycroft.model.task import TaskType, TaskStatus
 from pycroft.model.task_serialization import UserMoveParams
 from tests import FactoryDataTestBase
@@ -41,9 +42,11 @@ class TestTaskExecution(FactoryDataTestBase):
 
     def test_task_force_execute(self):
         force_execute_task(self.task, self.admin)
+        now = session.utcnow()
         self.session.commit()
 
         assert self.user.room == self.new_room
         assert self.task.status == TaskStatus.EXECUTED
+        assert self.task.due == now
         assert len(logs := self.task.log_entries) == 1
         assert logs[0].author == self.admin

--- a/tests/lib/test_task.py
+++ b/tests/lib/test_task.py
@@ -1,0 +1,49 @@
+#  Copyright (c) 2021. The Pycroft Authors. See the AUTHORS file.
+#  This file is part of the Pycroft project and licensed under the terms of
+#  the Apache License, Version 2.0. See the LICENSE file for details
+import datetime
+
+from pycroft.lib.task import cancel_task, force_execute_task
+from pycroft.model.task import TaskType, TaskStatus
+from pycroft.model.task_serialization import UserMoveParams
+from tests import FactoryDataTestBase
+from tests.factories import UserFactory, UserTaskFactory, RoomFactory
+
+
+class TestTaskExecution(FactoryDataTestBase):
+    def create_factories(self):
+        self.admin = UserFactory()
+        self.old_room = RoomFactory()
+        self.new_room = RoomFactory()
+        self.user = UserFactory(room=self.old_room)
+        self.task = UserTaskFactory(
+            user=self.user, type=TaskType.USER_MOVE,
+            created=datetime.datetime.now() - datetime.timedelta(days=1),
+            due=datetime.datetime.now() + datetime.timedelta(days=7),
+            parameters=UserMoveParams(room_number=self.new_room.number,
+                                      level=self.new_room.level,
+                                      building_id=self.new_room.building_id),
+            creator=self.admin,
+        )
+
+    def test_task_defaults(self):
+        assert self.task.status == TaskStatus.OPEN
+        assert self.task.errors is None
+
+    def test_task_cancel(self):
+        cancel_task(self.task, self.admin)
+        self.session.commit()
+
+        assert self.user.room == self.old_room
+        assert self.task.status == TaskStatus.CANCELLED
+        assert len(logs := self.task.log_entries) == 1
+        assert logs[0].author == self.admin
+
+    def test_task_force_execute(self):
+        force_execute_task(self.task, self.admin)
+        self.session.commit()
+
+        assert self.user.room == self.new_room
+        assert self.task.status == TaskStatus.EXECUTED
+        assert len(logs := self.task.log_entries) == 1
+        assert logs[0].author == self.admin

--- a/tests/lib/test_task.py
+++ b/tests/lib/test_task.py
@@ -3,7 +3,7 @@
 #  the Apache License, Version 2.0. See the LICENSE file for details
 import datetime
 
-from pycroft.lib.task import cancel_task, force_execute_task
+from pycroft.lib.task import cancel_task, manually_execute_task
 from pycroft.model import session
 from pycroft.model.task import TaskType, TaskStatus
 from pycroft.model.task_serialization import UserMoveParams
@@ -40,8 +40,8 @@ class TestTaskExecution(FactoryDataTestBase):
         assert len(logs := self.task.log_entries) == 1
         assert logs[0].author == self.admin
 
-    def test_task_force_execute(self):
-        force_execute_task(self.task, self.admin)
+    def test_task_manually_execute(self):
+        manually_execute_task(self.task, self.admin)
         now = session.utcnow()
         self.session.commit()
 

--- a/web/blueprints/__init__.py
+++ b/web/blueprints/__init__.py
@@ -1,7 +1,22 @@
 # Copyright (c) 2014 The Pycroft Authors. See the AUTHORS file.
 # This file is part of the Pycroft project and licensed under the terms of
 # the Apache License, Version 2.0. See the LICENSE file for details.
+from typing import Optional, Union, NoReturn
+
+from werkzeug import Response
+from werkzeug.exceptions import abort
+from werkzeug.utils import redirect
 
 
 def bake_endpoint(blueprint, fn):
     return "{}.{}".format(blueprint.name, fn.__name__)
+
+
+def redirect_or_404(redirect_url: Optional[str]) -> Union[Response, NoReturn]:
+    """Helper function to return a redirect or abort.
+
+    **The return vaue must be used!**
+    """
+    if redirect_url:
+        return redirect(redirect_url)
+    abort(404)

--- a/web/blueprints/task/__init__.py
+++ b/web/blueprints/task/__init__.py
@@ -26,9 +26,7 @@ nav = BlueprintNavigation(bp, "Tasks", blueprint_access=access)
 
 
 def format_parameters(parameters):
-    """
-    Makes parameters human readable
-    """
+    """Make task parameters human readable by looking up objects behind ids"""
 
     # Replace building_id by the buildings short name
     if parameters.get("building_id"):

--- a/web/blueprints/task/__init__.py
+++ b/web/blueprints/task/__init__.py
@@ -59,16 +59,24 @@ def task_row(task: Task):
             href=url_for('user.user_show', user_id=task.creator.id),
             title=task.creator.name
         ),
-        'actions': [T.actions.single_value(
-            href=url_for(
-                '.cancel_user_task',
-                task_id=task.id,
-                redirect=url_for('user.user_show', user_id=task.user.id, _anchor='tasks')
+        'actions': [
+            T.actions.single_value(
+                href=url_for(
+                    '.cancel_user_task',
+                    task_id=task.id,
+                    redirect=url_for('user.user_show', user_id=task.user.id, _anchor='tasks')
+                ),
+                title="Abbrechen",
+                icon='fa-times',
+                btn_class='btn-link'
             ),
-            title="Abbrechen",
-            icon='fa-times',
-            btn_class='btn-link'
-        )] if task.status == TaskStatus.OPEN else None,
+            T.actions.single_value(
+                href='#',
+                title="Sofort ausführen",
+                icon='fa-fast-forward',
+                btn_class='btn-link'
+            )
+        ] if task.status == TaskStatus.OPEN else None,
     }
 
 @bp.route("/user/<int:user_id>/json")

--- a/web/blueprints/task/__init__.py
+++ b/web/blueprints/task/__init__.py
@@ -6,7 +6,7 @@ from flask import Blueprint, jsonify, url_for, abort, flash, redirect, request, 
     render_template
 from flask_login import current_user
 
-from pycroft.lib.exc import PycroftLibException
+from pycroft.exc import PycroftException
 from pycroft.model import session
 
 from pycroft.lib.task import cancel_task, task_type_to_impl, manually_execute_task
@@ -119,7 +119,7 @@ def manually_execute_user_task(task_id: int):
         manually_execute_task(task, processor=current_user)
         session.session.commit()
     except Exception as e:
-        if not isinstance(e, PycroftLibException):
+        if not isinstance(e, PycroftException):
             import logging
             logging.getLogger('pycroft.web').error(
                 "Unexpected error in manual task execution: %s", e,

--- a/web/blueprints/task/__init__.py
+++ b/web/blueprints/task/__init__.py
@@ -8,7 +8,7 @@ from flask_login import current_user
 
 from pycroft.model import session
 
-from pycroft.lib.task import cancel_task, task_type_to_impl, force_execute_task
+from pycroft.lib.task import cancel_task, task_type_to_impl, manually_execute_task
 from pycroft.model.facilities import Building
 from pycroft.model.task import Task, TaskStatus
 from web.blueprints import redirect_or_404
@@ -72,7 +72,7 @@ def task_row(task: Task):
             ),
             T.actions.single_value(
                 href=url_for(
-                    '.force_execute_user_task',
+                    '.manually_execute_user_task',
                     task_id=task.id,
                     redirect=url_for('user.user_show', user_id=task.user.id, _anchor='tasks')
                 ),
@@ -113,12 +113,12 @@ def get_task_or_404(task_id) -> Union[Task, NoReturn]:
     abort(404)
 
 
-@bp.route("/<int:task_id>/force_execute")
+@bp.route("/<int:task_id>/manually_execute")
 @access.require('user_change')
-def force_execute_user_task(task_id: int):
+def manually_execute_user_task(task_id: int):
     task = get_task_or_404(task_id)
 
-    force_execute_task(task, processor=current_user)
+    manually_execute_task(task, processor=current_user)
     session.session.commit()
 
     flash("Aufgabe erfolgreich ausgeführt", 'success')

--- a/web/blueprints/task/__init__.py
+++ b/web/blueprints/task/__init__.py
@@ -132,14 +132,9 @@ def force_execute_user_task(task_id: int):
 @access.require('user_change')
 def cancel_user_task(task_id):
     redirect_url = request.args.get("redirect")
-
-    task = Task.get(task_id)
-
-    if task is None:
-        abort(404)
+    task = get_task_or_404(task_id)
 
     cancel_task(task, current_user)
-
     session.session.commit()
 
     flash(u'Aufgabe erfolgreich abgebrochen.', 'success')

--- a/web/blueprints/task/__init__.py
+++ b/web/blueprints/task/__init__.py
@@ -11,6 +11,7 @@ from pycroft.model import session
 from pycroft.lib.task import cancel_task, task_type_to_impl
 from pycroft.model.facilities import Building
 from pycroft.model.task import Task, TaskStatus
+from web.blueprints import redirect_or_404
 
 from web.blueprints.access import BlueprintAccess
 from web.table.table import datetime_format
@@ -123,26 +124,19 @@ def force_execute_user_task(task_id: int):
     # session.session.commit()
 
     flash("Aufgabe erfolgreich ausgeführt", 'success')
-    if redirect_url := request.args.get("redirect"):
-        return redirect(redirect_url)
-    return abort(404)
+    return redirect_or_404(request.args.get("redirect"))
 
 
 @bp.route("/<int:task_id>/cancel")
 @access.require('user_change')
 def cancel_user_task(task_id):
-    redirect_url = request.args.get("redirect")
     task = get_task_or_404(task_id)
 
     cancel_task(task, current_user)
     session.session.commit()
 
     flash(u'Aufgabe erfolgreich abgebrochen.', 'success')
-
-    if redirect_url:
-        return redirect(redirect_url)
-    else:
-        return abort(404)  # redirect(url_for('.tasks'))
+    return redirect_or_404(request.args.get("redirect"))
 
 
 @bp.route("/user")

--- a/web/blueprints/task/__init__.py
+++ b/web/blueprints/task/__init__.py
@@ -30,13 +30,10 @@ def format_parameters(parameters):
     """Make task parameters human readable by looking up objects behind ids"""
 
     # Replace building_id by the buildings short name
-    if parameters.get("building_id"):
-        building = Building.get(parameters["building_id"])
-
-        if building:
+    if bid := parameters.get("building_id"):
+        if building := Building.get(bid):
             parameters["building"] = building.short_name
             del parameters["building_id"]
-
     return parameters
 
 
@@ -151,12 +148,10 @@ def cancel_user_task(task_id):
 @bp.route("/user")
 @nav.navigate("Tasks")
 def user_tasks():
-    return render_template("task/tasks.html",
-                           task_table=TaskTable(
-                               data_url=url_for('.json_user_tasks',
-                                                open_only=1)),
-                           task_failed_table=TaskTable(
-                               data_url=url_for('.json_user_tasks',
-                                                failed_only=1),
-                               sort_order='desc'),
-                           page_title="Aufgaben (Nutzer)")
+    return render_template(
+        "task/tasks.html",
+        task_table=TaskTable(data_url=url_for('.json_user_tasks', open_only=1)),
+        task_failed_table=TaskTable(data_url=url_for('.json_user_tasks', failed_only=1),
+                                    sort_order='desc'),
+        page_title="Aufgaben (Nutzer)"
+    )

--- a/web/blueprints/task/__init__.py
+++ b/web/blueprints/task/__init__.py
@@ -8,7 +8,7 @@ from flask_login import current_user
 
 from pycroft.model import session
 
-from pycroft.lib.task import cancel_task, task_type_to_impl
+from pycroft.lib.task import cancel_task, task_type_to_impl, force_execute_task
 from pycroft.model.facilities import Building
 from pycroft.model.task import Task, TaskStatus
 from web.blueprints import redirect_or_404
@@ -118,8 +118,8 @@ def get_task_or_404(task_id) -> Union[Task, NoReturn]:
 def force_execute_user_task(task_id: int):
     task = get_task_or_404(task_id)
 
-    # TODO execute task immediately
-    # session.session.commit()
+    force_execute_task(task, processor=current_user)
+    session.session.commit()
 
     flash("Aufgabe erfolgreich ausgeführt", 'success')
     return redirect_or_404(request.args.get("redirect"))

--- a/web/blueprints/user/__init__.py
+++ b/web/blueprints/user/__init__.py
@@ -313,7 +313,7 @@ def user_show(user_id):
             },
             {
                 'id': 'tasks',
-                'name': 'Aufgaben',
+                'name': 'Tasks',
                 'badge': len(user.tasks),
                 'badge_color': '#d9534f' if len(user.tasks) > 0 else None
             },

--- a/web/blueprints/user/__init__.py
+++ b/web/blueprints/user/__init__.py
@@ -308,40 +308,48 @@ def user_show(user_id):
         tabs=[
             {
                 'id': 'hosts',
-                'name': 'Hosts & Interfaces',
+                'icon': 'fa-laptop',
+                'name': 'Hosts',
                 'badge': len(user.hosts)
             },
             {
                 'id': 'tasks',
+                'icon': 'fa-clipboard-check',
                 'name': 'Tasks',
                 'badge': len(user.tasks),
                 'badge_color': '#d9534f' if len(user.tasks) > 0 else None
             },
             {
                 'id': 'logs',
+                'icon': 'fa-list-ul',
                 'name': 'Logs',
                 'badge': len(user.log_entries)
             },
             {
                 'id': 'traffic',
+                'icon': 'fa-chart-area',
                 'name': 'Traffic',
             },
             {
                 'id': 'finance',
+                'icon': 'fa-euro-sign',
                 'name': 'Finanzen',
             },
             {
                 'id': 'groups',
+                'icon': 'fa-users-cog',
                 'name': 'Gruppen',
                 'badge': len(user.active_memberships())
             },
             {
                 'id': 'room_history',
+                'icon': 'fa-history',
                 'name': 'Wohnorte',
                 'badge': len(user.room_history_entries)
             },
             {
                 'id': 'tenancies',
+                'icon': 'fa-file-signature',
                 'name': 'Mietverträge',
                 'badge': len(user.tenancies),
                 'disabled': len(user.tenancies) == 0,

--- a/web/templates/user/user_show.html
+++ b/web/templates/user/user_show.html
@@ -30,6 +30,7 @@
                {{ 'aria-disabled="true"' if 'disabled' in tab and tab.disabled else "" }}
                id="tab-{{ tab.id }}" href="#{{ tab.id }}"
                data-bs-toggle="tab" data-bs-target="#{{ tab.id }}">
+              {% if tab.icon %}<i class="fas {{ tab.icon }}"></i> {% endif -%}
               {{ tab.name }}
               {% if 'badge' in tab and tab.badge %}
                 <span class="badge rounded-pill bg-light text-dark" style="{{ "background-color: " + tab.badge_color if 'badge_color' in tab else "" }}">

--- a/web/templates/user/user_show.html
+++ b/web/templates/user/user_show.html
@@ -32,7 +32,7 @@
                data-bs-toggle="tab" data-bs-target="#{{ tab.id }}">
               {{ tab.name }}
               {% if 'badge' in tab and tab.badge %}
-                <span class="badge rounded-pill bg-secondary" style="{{ "background-color: " + tab.badge_color if 'badge_color' in tab else "" }}">
+                <span class="badge rounded-pill bg-light text-dark" style="{{ "background-color: " + tab.badge_color if 'badge_color' in tab else "" }}">
                   {{ tab.badge }}
                 </span>
               {% endif %}


### PR DESCRIPTION
This changes some descriptions and turns the user tabs from this:
![image](https://user-images.githubusercontent.com/10060406/128218607-b6ec7604-4038-4403-aaca-c5b6dde8057e.png)
Into this:
![image](https://user-images.githubusercontent.com/10060406/128218726-3f3ca311-1bf9-429e-8b82-def63665062d.png)

I'd say this is a valuable change since I found myself scanning the page for the `Aufgaben` tab way too often. having a unified description and icons definitely helps me.
Also, I've noticed how my eyes first focused on the number badges, which provide the least important information, hence I've turned `bg-secondary` into `bg-light`.