### PR TITLE
Proposal: Replace `web_execute` by context manager and base exception

### DIFF
--- a/doc/arch/adr-005.rst
+++ b/doc/arch/adr-005.rst
@@ -1,0 +1,100 @@
+ADR005
+======
+
+:Number: 005
+:Title: Improved exception handling in views
+:Author: Lukas Juhrich
+:Created: 2021-12-21
+:Status: Approved
+
+.. contents:: Table of Contents
+
+Context
+-------
+The previous attempt to unify exception handling in blueprint views is done
+via a ``web_execute`` function, which acts as a proxy for a ``lib`` function call:
+
+.. code-block:: python
+
+   result, success = web_execute(
+       lib_function,
+       "Success message!",
+       arg1, arg2='foo',
+   )
+
+This is suboptimal in a few ways.
+
+Firstly, having a boolean result value is comparatively unpythonic.
+Context managers and exception handling are builtin language features which are
+designed to solve the problem such a boolean variable does.
+In addition, using exceptions for control flow is perfectly admissable in python.
+Looking different from usual, explicit function calls, also makes it harder to
+reason about correctness and easier to overlook errors.
+
+Secondly, it breaks code completion and signature checking of the function,
+both in IDEs and in Mypy.
+Absence of these protective mechanisms is a common source of error.
+
+The ``web_execute`` meta-function solves the following set of problems:
+1. It flashes error messages when a specific subset of internal errors occur
+2. consuming these internal exceptions
+3. It rolls back the session
+4. It flashes a success message if everything went great
+
+Nota bene: Recently a ``PycroftException`` has been introduced, making it easier
+to handle all of the relevant exceptions instead of relying on a hard-coded list
+to do that.
+
+In addition, a useful pattern recently emerged in some parts of the ``web`` code:
+The final template rendering has been extracted into a local
+``default_response`` functtion, which makes an early exit a la
+``return default_response()`` possible.
+This is a very useful pattern because it is straghtforward to reason about,
+and does not introduce any unneccessary visual complexity to this kind of
+branching, as e.g. an if/then/else/-block would.
+
+It seems appropriate to split up the responsibilities of ``web_execute`` like this:
+
+1. should be handled with a context manager, intercepting certain kinds of
+   exceptions (but not consuming then)
+2. should be handled with a ``try: … except PycroftException: pass`` block
+3. should be handled in a context manager, for convenience the same as in 1.
+4. should be issued by the view function explicitly,
+   because passing the string to a sub-function doing the flashing instead
+   has no benefit justifying this indirection.
+
+An example would look like this:
+
+.. code-block:: python
+
+  @bp.route('/foo')
+  def view():
+      form = FooForm()
+      def default_response():
+          return render_template('generic-form.html', form=form)
+
+      if not form.is_submitted():
+          _fill_defaults(form)
+          return default_response()
+      if not form.validate():
+          return default_response()
+
+      try:
+          with handle_errors(session):
+              lib.foo(bar=form.bar.data)
+              session.commit()
+      except PycroftException:
+          return default_response()
+
+      flash("Good job!", 'success')
+      return redirect(url_for('.bar'))
+
+Decision
+--------
+- Replace ``web_execute`` usages by ``handle_error`` usages
+- Promote early-exit pattern in functions which use one of the above constructs
+
+Consequences
+------------
+- Code completion for `lib` function calls will work again
+- View functions will become more readable

--- a/doc/index.rst
+++ b/doc/index.rst
@@ -29,4 +29,5 @@ Architecture decision records
    ADR002 - Continue using pickle as default serializer <arch/adr-002.rst>
    ADR003 - Use ``.table_valued`` wrapper for table valued sql functions <arch/adr-003.rst>
    ADR004 - Deprecate usage of ``session`` proxy in favor of dependency injection <arch/adr-004.rst>
+   ADR005 - Improved exception handling in views <arch/adr-005.rst>
    arch/*

--- a/web/blueprints/helpers/user.py
+++ b/web/blueprints/helpers/user.py
@@ -1,3 +1,5 @@
+from typing import NoReturn
+
 from flask import url_for, flash, abort
 from flask_login import current_user
 
@@ -75,7 +77,7 @@ def user_button(user):
     }
 
 
-def get_user_or_404(user_id):
+def get_user_or_404(user_id: int) -> User | NoReturn:
     user = User.get(user_id)
     if user is None:
         flash(f"Nutzer mit ID {user_id} existiert nicht!", 'error')

--- a/web/blueprints/host/__init__.py
+++ b/web/blueprints/host/__init__.py
@@ -27,15 +27,12 @@ access = BlueprintAccess(bp, required_properties=['user_show'])
 @bp.route('/<int:host_id>/delete', methods=['GET', 'POST'])
 @access.require('hosts_change')
 def host_delete(host_id):
-    host = Host.get(host_id)
-
-    if host is None:
+    if (host := Host.get(host_id)) is None:
         flash("Host existiert nicht.", 'error')
         abort(404)
-
+    owner = host.owner
     form = FlaskForm()
 
-    owner = host.owner
 
     if form.is_submitted():
         _, success = web_execute(lib_host.host_delete,
@@ -64,12 +61,9 @@ def host_delete(host_id):
 @bp.route('/<int:host_id>/edit', methods=['GET', 'POST'])
 @access.require('hosts_change')
 def host_edit(host_id):
-    host = Host.get(host_id)
-
-    if host is None:
+    if (host := Host.get(host_id)) is None:
         flash("Host existiert nicht.", 'error')
         abort(404)
-
     form = HostForm(obj=host)
 
     if not form.is_submitted():
@@ -146,9 +140,7 @@ def host_create():
 
 @bp.route("/<int:host_id>/interfaces")
 def host_interfaces_json(host_id):
-    host = Host.get(host_id)
-
-    if host is None:
+    if (host := Host.get(host_id)) is None:
         flash("Host existiert nicht.", 'error')
         abort(404)
 
@@ -194,9 +186,7 @@ def interface_table(host_id):
 @bp.route('/interface/<int:interface_id>/delete', methods=['GET', 'POST'])
 @access.require('hosts_change')
 def interface_delete(interface_id):
-    interface = Interface.get(interface_id)
-
-    if interface is None:
+    if (interface := Interface.get(interface_id)) is None:
         flash("Interface existiert nicht.", 'error')
         abort(404)
 
@@ -230,21 +220,16 @@ def interface_delete(interface_id):
 @bp.route('/interface/<int:interface_id>/edit', methods=['GET', 'POST'])
 @access.require('hosts_change')
 def interface_edit(interface_id):
-    interface = Interface.get(interface_id)
-
-    if interface is None:
+    if (interface := Interface.get(interface_id)) is None:
         flash("Interface existiert nicht.", 'error')
         abort(404)
 
     subnets = get_subnets_for_room(interface.host.room)
-
-    current_ips = list(ip.address for ip in interface.ips)
+    current_ips = [ip.address for ip in interface.ips]
 
     form = InterfaceForm(obj=interface)
     form.meta.current_mac = interface.mac
-
     unused_ips = [ip for ips in get_unused_ips(subnets).values() for ip in ips]
-
     form.ips.choices = [(str(ip), str(ip)) for ip in current_ips + unused_ips]
 
     if not form.is_submitted():
@@ -282,18 +267,13 @@ def interface_edit(interface_id):
 @bp.route('/<int:host_id>/interface/create', methods=['GET', 'POST'])
 @access.require('hosts_change')
 def interface_create(host_id):
-    host = Host.get(host_id)
-
-    if host is None:
+    if (host := Host.get(host_id)) is None:
         flash("Host existiert nicht.", 'error')
         abort(404)
 
     subnets = get_subnets_for_room(host.room)
-
     form = InterfaceForm()
-
     unused_ips = [ip for ips in get_unused_ips(subnets).values() for ip in ips]
-
     form.ips.choices = [(str(ip), str(ip)) for ip in unused_ips]
 
     if not form.is_submitted():


### PR DESCRIPTION
@ibot3 Can you give me some feedback on this idea?
(Also relates to #493)

As mentioned previously, the value proposal is that calling functions directly can leverage IDE autocompletion and static analysis (i.e. type hints, or even just “knowing the function signature”). A call of the form `web_execute(func, success_message, *actual_arguments)` makes this impossible and is harder to reason about.