### PR TITLE
set up semgrep

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -5,3 +5,9 @@ repos:
     hooks:
     -   id: pyupgrade
         args: ["--py310-plus"]
+- repo: https://github.com/returntocorp/semgrep
+  rev: 'v0.80.0'
+  hooks:
+  - id: semgrep
+    # See semgrep.dev/rulesets to select a ruleset and copy its URL
+    args: ['--config', 'tools/semgrep.yml', '--error', '--skip-unknown-extensions']    

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -10,4 +10,4 @@ repos:
   hooks:
   - id: semgrep
     # See semgrep.dev/rulesets to select a ruleset and copy its URL
-    args: ['--config', 'tools/semgrep.yml', '--error', '--skip-unknown-extensions']    
+    args: ['--config', 'tools/semgrep.yml', '--metrics=off', '--error', '--skip-unknown-extensions']    

--- a/pycroft/lib/facilities.py
+++ b/pycroft/lib/facilities.py
@@ -103,14 +103,16 @@ def edit_room(room, number, inhabitable, vo_suchname: str, address: Address, pro
         room.inhabitable = inhabitable
 
     if room.swdd_vo_suchname != vo_suchname:
-        log_room_event("Changed VO id from {} to {}.".format(room.swdd_vo_suchname,
-                                                             vo_suchname), processor, room)
-
+        log_room_event(
+            deferred_gettext("Changed VO id from {} to {}.")
+                .format(room.swdd_vo_suchname, vo_suchname).to_json(),
+            processor, room
+        )
         room.swdd_vo_suchname = vo_suchname
 
     if room.address != address:
         room.address = address
-        log_room_event(deferred_gettext(f"Changed address to {address}").to_json(),
+        log_room_event(deferred_gettext("Changed address to {}").format(str(address)).to_json(),
                        processor, room)
         for user in room.users_sharing_address:
             user.address = room.address

--- a/pycroft/lib/host.py
+++ b/pycroft/lib/host.py
@@ -102,7 +102,7 @@ def host_edit(host, owner, room, name, processor):
 
 @with_transaction
 def host_delete(host, processor):
-    message = deferred_gettext(f"Deleted host '{host.name}'.")
+    message = deferred_gettext("Deleted host '{}'.").format(host.name)
     log_user_event(author=processor,
                    user=host.owner,
                    message=message.to_json())

--- a/pycroft/lib/user.py
+++ b/pycroft/lib/user.py
@@ -576,8 +576,8 @@ def edit_email(user: User, email: str | None, email_forwarded: bool, processor: 
         user.email_forwarded = email_forwarded
 
         log_user_event(author=processor, user=user,
-                       message=deferred_gettext(
-                           f"Set e-mail forwarding to {email_forwarded}.").to_json())
+                       message=deferred_gettext("Set e-mail forwarding to {}.")
+                               .format(email_forwarded).to_json())
 
     if is_confirmed:
         user.email_confirmed = True

--- a/pycroft/model/alembic/script.py.mako
+++ b/pycroft/model/alembic/script.py.mako
@@ -7,7 +7,6 @@ Create Date: ${create_date}
 """
 from alembic import op
 import sqlalchemy as sa
-import pycroft
 ${imports if imports else ""}
 
 # revision identifiers, used by Alembic.

--- a/pycroft/model/alembic/versions/08fa5b3cc555_add_some_groups_to_config.py
+++ b/pycroft/model/alembic/versions/08fa5b3cc555_add_some_groups_to_config.py
@@ -5,10 +5,8 @@ Revises: 92ee63f41c5b
 Create Date: 2018-11-27 21:41:36.657526
 
 """
-from alembic import op
 import sqlalchemy as sa
-import pycroft
-
+from alembic import op
 
 # revision identifiers, used by Alembic.
 revision = '08fa5b3cc555'

--- a/pycroft/model/alembic/versions/0b69e80a9388_remove_config_cache_group_id.py
+++ b/pycroft/model/alembic/versions/0b69e80a9388_remove_config_cache_group_id.py
@@ -5,10 +5,8 @@ Revises: 28e56bf6f62c
 Create Date: 2021-05-20 23:44:18.520232
 
 """
-from alembic import op
 import sqlalchemy as sa
-import pycroft
-
+from alembic import op
 
 # revision identifiers, used by Alembic.
 revision = '0b69e80a9388'

--- a/pycroft/model/alembic/versions/28e56bf6f62c_add_triggers_for_cleanup_of_address_.py
+++ b/pycroft/model/alembic/versions/28e56bf6f62c_add_triggers_for_cleanup_of_address_.py
@@ -6,9 +6,6 @@ Create Date: 2021-02-12 02:07:00.403096
 
 """
 from alembic import op
-import sqlalchemy as sa
-import pycroft
-
 
 # revision identifiers, used by Alembic.
 revision = '28e56bf6f62c'

--- a/pycroft/model/alembic/versions/2a83876e83ae_allow_deleting_of_unix_accounts.py
+++ b/pycroft/model/alembic/versions/2a83876e83ae_allow_deleting_of_unix_accounts.py
@@ -6,9 +6,6 @@ Create Date: 2019-10-10 16:10:17.945164
 
 """
 from alembic import op
-import sqlalchemy as sa
-import pycroft
-
 
 # revision identifiers, used by Alembic.
 revision = '2a83876e83ae'

--- a/pycroft/model/alembic/versions/305a51819d48_add_tasks.py
+++ b/pycroft/model/alembic/versions/305a51819d48_add_tasks.py
@@ -5,9 +5,8 @@ Revises: ae8f4b63876a
 Create Date: 2019-05-24 09:38:15.831712
 
 """
-from alembic import op
 import sqlalchemy as sa
-import pycroft
+from alembic import op
 from sqlalchemy.dialects import postgresql
 
 # revision identifiers, used by Alembic.
@@ -25,9 +24,9 @@ def upgrade():
     sa.Column('id', sa.Integer(), nullable=False),
     sa.Column('task_type', sa.String(length=50), nullable=True),
     sa.Column('type', task_type, nullable=False),
-    sa.Column('due', pycroft.model.types.DateTimeTz(), nullable=False),
+    sa.Column('due', sa.types.DateTime(timezone=True), nullable=False),
     sa.Column('parameters', postgresql.JSONB(astext_type=sa.Text()), nullable=False),
-    sa.Column('created', pycroft.model.types.DateTimeTz(), nullable=False),
+    sa.Column('created', sa.types.DateTime(timezone=True), nullable=False),
     sa.Column('creator_id', sa.Integer(), nullable=False),
     sa.Column('status', task_status, nullable=False),
     sa.Column('errors', postgresql.JSONB(astext_type=sa.Text()), nullable=True),

--- a/pycroft/model/alembic/versions/37b57e0baa3a_remove_length_restriction_on_patchport_.py
+++ b/pycroft/model/alembic/versions/37b57e0baa3a_remove_length_restriction_on_patchport_.py
@@ -5,10 +5,8 @@ Revises: cff476c9a54d
 Create Date: 2020-02-13 14:27:39.757050
 
 """
-from alembic import op
 import sqlalchemy as sa
-import pycroft
-
+from alembic import op
 
 # revision identifiers, used by Alembic.
 revision = '37b57e0baa3a'

--- a/pycroft/model/alembic/versions/38fa5154b920_allow_deleting_of_switch_ports.py
+++ b/pycroft/model/alembic/versions/38fa5154b920_allow_deleting_of_switch_ports.py
@@ -6,9 +6,6 @@ Create Date: 2019-10-10 16:18:01.348782
 
 """
 from alembic import op
-import sqlalchemy as sa
-import pycroft
-
 
 # revision identifiers, used by Alembic.
 revision = '38fa5154b920'

--- a/pycroft/model/alembic/versions/3ec1d29bfd10_add_fints_product_id.py
+++ b/pycroft/model/alembic/versions/3ec1d29bfd10_add_fints_product_id.py
@@ -5,10 +5,8 @@ Revises: 37b57e0baa3a
 Create Date: 2020-05-06 21:02:42.433050
 
 """
-from alembic import op
 import sqlalchemy as sa
-import pycroft
-
+from alembic import op
 
 # revision identifiers, used by Alembic.
 revision = '3ec1d29bfd10'

--- a/pycroft/model/alembic/versions/4784a128a6dd_empty_revision.py
+++ b/pycroft/model/alembic/versions/4784a128a6dd_empty_revision.py
@@ -12,11 +12,6 @@ Create Date: 2017-12-13 00:48:12.079431
 
 """
 
-from alembic import op
-import sqlalchemy as sa
-import pycroft
-
-
 # revision identifiers, used by Alembic.
 revision = '4784a128a6dd'
 down_revision = None

--- a/pycroft/model/alembic/versions/4e7eb2d1e44e_revise_subnet_address_reservation.py
+++ b/pycroft/model/alembic/versions/4e7eb2d1e44e_revise_subnet_address_reservation.py
@@ -5,9 +5,8 @@ Revises: 4784a128a6dd
 Create Date: 2018-09-01 09:06:06.227707
 
 """
-from alembic import op
 import sqlalchemy as sa
-import pycroft
+from alembic import op
 
 # revision identifiers, used by Alembic.
 revision = '4e7eb2d1e44e'

--- a/pycroft/model/alembic/versions/5905825242ff_add_password_token.py
+++ b/pycroft/model/alembic/versions/5905825242ff_add_password_token.py
@@ -5,10 +5,8 @@ Revises: d8cfeaaee75d
 Create Date: 2021-01-17 11:24:32.036420
 
 """
-from alembic import op
 import sqlalchemy as sa
-import pycroft
-
+from alembic import op
 
 # revision identifiers, used by Alembic.
 revision = '5905825242ff'

--- a/pycroft/model/alembic/versions/5b6f5a33e426_undo_set_null_for_user_unix_account_id.py
+++ b/pycroft/model/alembic/versions/5b6f5a33e426_undo_set_null_for_user_unix_account_id.py
@@ -6,9 +6,6 @@ Create Date: 2019-10-13 23:03:12.165450
 
 """
 from alembic import op
-import sqlalchemy as sa
-import pycroft
-
 
 # revision identifiers, used by Alembic.
 revision = '5b6f5a33e426'

--- a/pycroft/model/alembic/versions/6815546f681c_add_exclusion_constraint_to_membership.py
+++ b/pycroft/model/alembic/versions/6815546f681c_add_exclusion_constraint_to_membership.py
@@ -6,9 +6,6 @@ Create Date: 2021-11-14 00:38:58.192514
 
 """
 from alembic import op
-import sqlalchemy as sa
-import pycroft
-
 
 # revision identifiers, used by Alembic.
 revision = '6815546f681c'

--- a/pycroft/model/alembic/versions/6f1a37baa574_hosts_and_interfaces.py
+++ b/pycroft/model/alembic/versions/6f1a37baa574_hosts_and_interfaces.py
@@ -6,11 +6,7 @@ Create Date: 2018-09-17 15:38:56.401301
 
 """
 from alembic import op
-import sqlalchemy as sa
 from sqlalchemy import table, column, String
-
-import pycroft
-
 
 # revision identifiers, used by Alembic.
 revision = '6f1a37baa574'

--- a/pycroft/model/alembic/versions/7855ecffe722_fix_finance_triggers.py
+++ b/pycroft/model/alembic/versions/7855ecffe722_fix_finance_triggers.py
@@ -6,9 +6,6 @@ Create Date: 2019-03-05 23:22:32.642764
 
 """
 from alembic import op
-import sqlalchemy as sa
-import pycroft
-
 
 # revision identifiers, used by Alembic.
 revision = '7855ecffe722'
@@ -35,9 +32,9 @@ def upgrade():
           ELSE
             s := COALESCE(NEW, OLD);
           END IF;
-          
+
           SELECT COUNT(*) = 0 INTO transaction_deleted FROM "transaction" WHERE "id" = s.transaction_id;
-            
+
           SELECT COUNT(*), SUM(amount) INTO STRICT count, balance FROM split
               WHERE transaction_id = s.transaction_id;
           IF count < 2 AND NOT transaction_deleted THEN

--- a/pycroft/model/alembic/versions/7a6449f2489c_infrastructure_change.py
+++ b/pycroft/model/alembic/versions/7a6449f2489c_infrastructure_change.py
@@ -5,10 +5,8 @@ Revises: 8ff6f90b98fa
 Create Date: 2018-12-20 23:10:49.889221
 
 """
-from alembic import op
 import sqlalchemy as sa
-import pycroft
-
+from alembic import op
 
 # revision identifiers, used by Alembic.
 revision = '7a6449f2489c'

--- a/pycroft/model/alembic/versions/7c1927c937af_add_permission_level_for_property_groups.py
+++ b/pycroft/model/alembic/versions/7c1927c937af_add_permission_level_for_property_groups.py
@@ -5,10 +5,8 @@ Revises: ff0dbccdf410
 Create Date: 2019-06-01 20:03:20.487616
 
 """
-from alembic import op
 import sqlalchemy as sa
-import pycroft
-
+from alembic import op
 
 # revision identifiers, used by Alembic.
 revision = '7c1927c937af'

--- a/pycroft/model/alembic/versions/8ff6f90b98fa_add_table_for_mt940_parsing_errors.py
+++ b/pycroft/model/alembic/versions/8ff6f90b98fa_add_table_for_mt940_parsing_errors.py
@@ -5,10 +5,10 @@ Revises: 08fa5b3cc555
 Create Date: 2018-12-20 18:34:05.289624
 
 """
-from alembic import op
 import sqlalchemy as sa
+from alembic import op
+
 import pycroft
-from sqlalchemy.dialects import postgresql
 
 # revision identifiers, used by Alembic.
 revision = '8ff6f90b98fa'

--- a/pycroft/model/alembic/versions/8ff6f90b98fa_add_table_for_mt940_parsing_errors.py
+++ b/pycroft/model/alembic/versions/8ff6f90b98fa_add_table_for_mt940_parsing_errors.py
@@ -8,8 +8,6 @@ Create Date: 2018-12-20 18:34:05.289624
 import sqlalchemy as sa
 from alembic import op
 
-import pycroft
-
 # revision identifiers, used by Alembic.
 revision = '8ff6f90b98fa'
 down_revision = '08fa5b3cc555'
@@ -23,7 +21,7 @@ def upgrade():
     sa.Column('mt940', sa.Text(), nullable=False),
     sa.Column('exception', sa.Text(), nullable=False),
     sa.Column('author_id', sa.Integer(), nullable=False),
-    sa.Column('imported_at', pycroft.model.types.DateTimeTz(), server_default=sa.text('CURRENT_TIMESTAMP'), nullable=False),
+    sa.Column('imported_at', sa.types.DateTime(timezone=True), server_default=sa.text('CURRENT_TIMESTAMP'), nullable=False),
     sa.Column('bank_account_id', sa.Integer(), nullable=False),
     sa.ForeignKeyConstraint(['author_id'], ['user.id'], ),
     sa.ForeignKeyConstraint(['bank_account_id'], ['bank_account.id'], ),

--- a/pycroft/model/alembic/versions/92ee63f41c5b_make_membership_fees_more_flexible.py
+++ b/pycroft/model/alembic/versions/92ee63f41c5b_make_membership_fees_more_flexible.py
@@ -7,9 +7,8 @@ Create Date: 2018-11-01 14:57:25.498035
 """
 from datetime import timedelta
 
-from alembic import op
 import sqlalchemy as sa
-import pycroft
+from alembic import op
 from sqlalchemy.dialects import postgresql
 
 # revision identifiers, used by Alembic.

--- a/pycroft/model/alembic/versions/a32def81e36a_add_name_attribute_to_host.py
+++ b/pycroft/model/alembic/versions/a32def81e36a_add_name_attribute_to_host.py
@@ -5,10 +5,8 @@ Revises: 4e7eb2d1e44e
 Create Date: 2018-09-02 15:34:02.873730
 
 """
-from alembic import op
 import sqlalchemy as sa
-import pycroft
-
+from alembic import op
 
 # revision identifiers, used by Alembic.
 revision = 'a32def81e36a'

--- a/pycroft/model/alembic/versions/a522fc7626e9_add_legacy_status_to_accounts.py
+++ b/pycroft/model/alembic/versions/a522fc7626e9_add_legacy_status_to_accounts.py
@@ -5,10 +5,8 @@ Revises: 305a51819d48
 Create Date: 2019-06-08 15:41:16.250781
 
 """
-from alembic import op
 import sqlalchemy as sa
-import pycroft
-
+from alembic import op
 
 # revision identifiers, used by Alembic.
 revision = 'a522fc7626e9'

--- a/pycroft/model/alembic/versions/ae8f4b63876a_add_confirmed_status_to_transaction.py
+++ b/pycroft/model/alembic/versions/ae8f4b63876a_add_confirmed_status_to_transaction.py
@@ -5,10 +5,8 @@ Revises: 7c1927c937af
 Create Date: 2019-05-31 18:08:19.462983
 
 """
-from alembic import op
 import sqlalchemy as sa
-import pycroft
-
+from alembic import op
 
 # revision identifiers, used by Alembic.
 revision = 'ae8f4b63876a'

--- a/pycroft/model/alembic/versions/cd588620e7d0_add_bankaccount_used_for_usersheets_to_.py
+++ b/pycroft/model/alembic/versions/cd588620e7d0_add_bankaccount_used_for_usersheets_to_.py
@@ -5,11 +5,9 @@ Revises: a32def81e36a
 Create Date: 2018-09-10 21:54:26.977248
 
 """
-from alembic import op
 import sqlalchemy as sa
+from alembic import op
 from sqlalchemy.sql import table
-import pycroft
-
 
 # revision identifiers, used by Alembic.
 revision = 'cd588620e7d0'

--- a/pycroft/model/alembic/versions/ce8c8cebcbf4_make_address_state_and_addition_not_null.py
+++ b/pycroft/model/alembic/versions/ce8c8cebcbf4_make_address_state_and_addition_not_null.py
@@ -5,10 +5,8 @@ Revises: 38fa5154b920
 Create Date: 2019-10-13 21:24:39.752497
 
 """
-from alembic import op
 import sqlalchemy as sa
-import pycroft
-
+from alembic import op
 
 # revision identifiers, used by Alembic.
 revision = 'ce8c8cebcbf4'

--- a/pycroft/model/alembic/versions/cff476c9a54d_add_field_which_indicates_a_building_.py
+++ b/pycroft/model/alembic/versions/cff476c9a54d_add_field_which_indicates_a_building_.py
@@ -5,9 +5,8 @@ Revises: ce8c8cebcbf4
 Create Date: 2019-12-18 23:17:55.840237
 
 """
-from alembic import op
 import sqlalchemy as sa
-import pycroft
+from alembic import op
 
 # revision identifiers, used by Alembic.
 revision = 'cff476c9a54d'

--- a/pycroft/model/alembic/versions/d8cfeaaee75d_online_reg.py
+++ b/pycroft/model/alembic/versions/d8cfeaaee75d_online_reg.py
@@ -8,8 +8,6 @@ Create Date: 2020-08-18 15:04:02.034638
 import sqlalchemy as sa
 from alembic import op
 
-import pycroft
-
 # revision identifiers, used by Alembic.
 revision = 'd8cfeaaee75d'
 down_revision = 'c11d3d8b16ae'
@@ -23,7 +21,7 @@ def upgrade():
                     sa.Column('id', sa.Integer(), nullable=False),
                     sa.Column('login', sa.String(length=40), nullable=False),
                     sa.Column('name', sa.String(length=255), nullable=False),
-                    sa.Column('registered_at', pycroft.model.types.DateTimeTz(), nullable=False),
+                    sa.Column('registered_at', sa.types.DateTime(timezone=True), nullable=False),
                     sa.Column('passwd_hash', sa.String(), nullable=False),
                     sa.Column('email', sa.String(length=255), nullable=True),
                     sa.Column('email_confirmed', sa.Boolean(), server_default='False',

--- a/pycroft/model/alembic/versions/f138079b24c5_use_bytea_instead_of_textfor_web_.py
+++ b/pycroft/model/alembic/versions/f138079b24c5_use_bytea_instead_of_textfor_web_.py
@@ -5,10 +5,8 @@ Revises: 0e78d83dad0b
 Create Date: 2021-10-24 15:06:41.186366
 
 """
-from alembic import op
 import sqlalchemy as sa
-import pycroft
-
+from alembic import op
 
 # revision identifiers, used by Alembic.
 revision = 'f138079b24c5'

--- a/pycroft/model/alembic/versions/f85ef1ef556c_add_wifi_password.py
+++ b/pycroft/model/alembic/versions/f85ef1ef556c_add_wifi_password.py
@@ -5,10 +5,8 @@ Revises: a522fc7626e9
 Create Date: 2019-09-29 10:24:17.113268
 
 """
-from alembic import op
 import sqlalchemy as sa
-import pycroft
-
+from alembic import op
 
 # revision identifiers, used by Alembic.
 revision = 'f85ef1ef556c'

--- a/pycroft/model/alembic/versions/f8f1883f81af_allow_deleting_of_rooms.py
+++ b/pycroft/model/alembic/versions/f8f1883f81af_allow_deleting_of_rooms.py
@@ -6,9 +6,6 @@ Create Date: 2019-10-10 15:24:33.797124
 
 """
 from alembic import op
-import sqlalchemy as sa
-import pycroft
-
 
 # revision identifiers, used by Alembic.
 revision = 'f8f1883f81af'

--- a/pycroft/model/alembic/versions/ff0dbccdf410_add_column_for_interface_name.py
+++ b/pycroft/model/alembic/versions/ff0dbccdf410_add_column_for_interface_name.py
@@ -5,10 +5,8 @@ Revises: 7855ecffe722
 Create Date: 2019-04-15 14:48:01.856158
 
 """
-from alembic import op
 import sqlalchemy as sa
-import pycroft
-
+from alembic import op
 
 # revision identifiers, used by Alembic.
 revision = 'ff0dbccdf410'

--- a/pycroft/model/alembic/versions/ff700db83195_add_address_relation.py
+++ b/pycroft/model/alembic/versions/ff700db83195_add_address_relation.py
@@ -5,12 +5,11 @@ Revises: f85ef1ef556c
 Create Date: 2019-10-03 19:15:55.716640
 
 """
-from typing import List, Callable
+from typing import Callable
 
 import sqlalchemy as sa
 from alembic import op
 from sqlalchemy import orm
-
 from sqlalchemy.orm import declarative_base
 
 # revision identifiers, used by Alembic.

--- a/tools/semgrep.yml
+++ b/tools/semgrep.yml
@@ -52,3 +52,32 @@ rules:
     fix: secret_$FIELD = PasswordField($...ARGS)
     languages: [python]
     severity: ERROR
+
+  - id: dont-use-datetimetz-in-migrations
+    pattern-either:
+      - pattern: pycroft.model.types.DateTimeTz()
+    fix: sa.types.DateTime(timezone=True)
+    message: use sqlalchemys own DateTime instead of DateTimeTz for migrations
+    languages: [python]
+    severity: ERROR
+    paths:
+      include:
+        - "**/alembic/versions"
+
+  - id: dont-use-models-in-migrations
+    patterns:
+      - pattern-either:
+        - pattern: import pycroft
+        - pattern: import pycroft.model
+        - pattern: from pycroft import $FOO
+        - pattern: from pycroft.model import $FOO
+    message: |
+      Don't use pycroft models or other code in migrations!
+      The migrations must be able to run at any time regardless of how the code changes.
+      Custom data types have to be replaced by their sqlalchemy qualifier as well.
+    languages: [python]
+    severity: ERROR
+    paths:
+      include:
+        - "**/alembic/versions"
+

--- a/tools/semgrep.yml
+++ b/tools/semgrep.yml
@@ -32,3 +32,23 @@ rules:
     fix: $C.get($ARG)
     languages: [python]
     severity: ERROR
+
+  - id: secure-name-for-password-fields
+    patterns:
+      - pattern: $FIELD = $CLASS($...ARGS)
+      - pattern-inside: |
+            class $FORMCLASS: ...
+      - metavariable-pattern:
+          metavariable: $CLASS
+          pattern-either:
+            - pattern: wtforms_widgets.fields.core.PasswordField
+            - pattern: wtforms.fields.PasswordField
+            - pattern: PasswordField
+      - metavariable-pattern:
+          metavariable: $FIELD
+          patterns:
+            - pattern-not-regex: (password|secret)
+    message: $FIELD is not a secure name
+    fix: secret_$FIELD = PasswordField($...ARGS)
+    languages: [python]
+    severity: ERROR

--- a/tools/semgrep.yml
+++ b/tools/semgrep.yml
@@ -1,0 +1,34 @@
+# run with `pip install semgrep && semgrep --config=tools/semgrep.yml pycroft web` 
+# …or let `pre-commit` do the heavy lifting for you!
+rules:
+  - id: f-string-in-deferred-gettext
+    pattern: pycroft.helpers.i18n.deferred_gettext(f"...")
+    message: Don't use f-strings in `deferred_gettext`
+    languages: [python]
+    severity: ERROR
+  - id: format-in-deferred-gettext
+    pattern: pycroft.helpers.i18n.deferred_gettext("$MESSAGE".format($ARGS))
+    fix: deferred_gettext("$MESSAGE").format($ARGS).to_json()
+    message: Don't use formatted literals in `deferred_gettext`
+    languages: [python]
+    severity: ERROR
+  - id: log_event_with_format
+    patterns:
+      - pattern: ("$MESSAGE".format($ARGS))
+      - pattern-inside: $LOG_FN(...)
+      - metavariable-regex:
+          metavariable: $LOG_FN
+          regex: log_.*event
+    message: Don't use $LOG_FN with a pre-formatted string literal. Use `deferred-gettext` instead.
+    fix: $LOG_FN(deferred_gettext("$MESSAGE").format($ARGS).to_json())
+    languages: [python]
+    severity: ERROR
+  - id: do-not-call-get-with-keywords
+    pattern-either: 
+      - pattern: pycroft.model.$C.get(id=$ARG)
+      - pattern: pycroft.model._all.$C.get(id=$ARG)
+      - pattern: pycroft.model.$MODULE.$C.get(id=$ARG)
+    message: don't use `$C.get()` with a keyword argument
+    fix: $C.get($ARG)
+    languages: [python]
+    severity: ERROR

--- a/web/blueprints/finance/__init__.py
+++ b/web/blueprints/finance/__init__.py
@@ -178,7 +178,7 @@ def bank_accounts_import():
             fints = FinTS3Client(
                 bank_account.routing_number,
                 form.user.data,
-                form.pin.data,
+                form.secret_pin.data,
                 bank_account.fints_endpoint,
                 product_id=config.fints_product_id
             )

--- a/web/blueprints/finance/forms.py
+++ b/web/blueprints/finance/forms.py
@@ -110,7 +110,7 @@ class BankAccountActivityEditForm(BankAccountActivityReadForm):
 class BankAccountActivitiesImportForm(Form):
     account = SelectField("Bankkonto", coerce=int)
     user = StringField("Loginname", validators=[DataRequired()])
-    pin = PasswordField("PIN", validators=[DataRequired()])
+    secret_pin = PasswordField("PIN", validators=[DataRequired()])
     start_date = DateField("Startdatum")
     end_date = DateField("Enddatum")
     do_import = BooleanField("Import durchführen", default=False)


### PR DESCRIPTION
This PR
- Sets up [`semgrep`](https://semgrep.dev/docs/writing-rules/overview/) as part of `pre-commit`
- adds some sensible semgrep tests && fixes them:
  - migrations should not import production code (as it is subject to change)
  - `PasswordField`s should contain `password` or `secret` to help stupid sanitization regexes
  - log messages (e.g. those passed to `log_user_event`) should be formatted correctly using `deferred_gettext`