### PR TITLE
Fix bootstrap-table build after update

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -16,7 +16,7 @@
         "bootstrap": "^5.0.1",
         "bootstrap-3-typeahead": "^4.0.2",
         "bootstrap-datepicker": "^1.7.1",
-        "bootstrap-table": "^1.20.0",
+        "bootstrap-table": "^1.20.1",
         "core-js": "^3.9.1",
         "crossfilter": "^1.3.12",
         "d3": "^3.5.17",
@@ -2451,9 +2451,9 @@
       }
     },
     "node_modules/bootstrap-table": {
-      "version": "1.20.0",
-      "resolved": "https://registry.npmjs.org/bootstrap-table/-/bootstrap-table-1.20.0.tgz",
-      "integrity": "sha512-e6lOTG44aAeSFuOqFSjuMakXUlVF2jSkgtlDqa2lXbwq/Hn3Sn4TMSSJgSKdMnwX8WOpdlF3DIGUKQLiQ9vlXA==",
+      "version": "1.20.1",
+      "resolved": "https://registry.npmjs.org/bootstrap-table/-/bootstrap-table-1.20.1.tgz",
+      "integrity": "sha512-DNZdvb4VqpXp4+lGBWjnsMkEvsLn8uhTImamD3FBd/zPbcsncgSTAZNlB++K5JSdon+vnl2H8bDcz/Y6vrpkxg==",
       "peerDependencies": {
         "jquery": "1.9.1 - 3"
       }
@@ -11479,9 +11479,9 @@
       }
     },
     "bootstrap-table": {
-      "version": "1.20.0",
-      "resolved": "https://registry.npmjs.org/bootstrap-table/-/bootstrap-table-1.20.0.tgz",
-      "integrity": "sha512-e6lOTG44aAeSFuOqFSjuMakXUlVF2jSkgtlDqa2lXbwq/Hn3Sn4TMSSJgSKdMnwX8WOpdlF3DIGUKQLiQ9vlXA==",
+      "version": "1.20.1",
+      "resolved": "https://registry.npmjs.org/bootstrap-table/-/bootstrap-table-1.20.1.tgz",
+      "integrity": "sha512-DNZdvb4VqpXp4+lGBWjnsMkEvsLn8uhTImamD3FBd/zPbcsncgSTAZNlB++K5JSdon+vnl2H8bDcz/Y6vrpkxg==",
       "requires": {}
     },
     "brace-expansion": {

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "bootstrap": "^5.0.1",
     "bootstrap-3-typeahead": "^4.0.2",
     "bootstrap-datepicker": "^1.7.1",
-    "bootstrap-table": "^1.20.0",
+    "bootstrap-table": "^1.20.1",
     "core-js": "^3.9.1",
     "crossfilter": "^1.3.12",
     "d3": "^3.5.17",

--- a/tests/table/test_bootstrap_table.py
+++ b/tests/table/test_bootstrap_table.py
@@ -199,10 +199,17 @@ class TestEmptyTableDefaults:
 
     def test_table_args_set(self, EmptyTable):
         assert hasattr(EmptyTable, '_table_args'), "Attribute _table_args not set after class creation"
-        assert dict(EmptyTable._table_args) == {'data-toggle': "table"}
+        assert dict(EmptyTable._table_args) == {
+            'data-toggle': "table",
+            "data-icons-prefix": "fa",
+        }
 
     def test_table_args_after_instantiation(self, EmptyTable):
-        assert EmptyTable("#").table_args == {'data-toggle': "table", 'data-url': "#"}
+        assert EmptyTable("#").table_args == {
+            'data-toggle': "table",
+            "data-icons-prefix": "fa",
+            'data-url': "#",
+        }
 
 
 class TestTableArgs:

--- a/web/resources/js/table.js
+++ b/web/resources/js/table.js
@@ -126,7 +126,7 @@ export function userFormatter(value, row, index) {
     } else if (value['type'] === 'native') {
         return linkFormatter(value, row, index);
     } else {
-        console.log("ERROR: The following object could not be formatted by a userLogger:", value);
+        console.error("The following object could not be formatted by a userLogger:", value);
         return "Invalid format";
     }
 }

--- a/web/resources/js/table.js
+++ b/web/resources/js/table.js
@@ -11,6 +11,19 @@ import TimeAgo from 'javascript-time-ago'
 import de from 'javascript-time-ago/locale/de'
 
 $.extend($.fn.bootstrapTable.defaults, $.fn.bootstrapTable.locales['de-DE'])
+$.extend($.fn.bootstrapTable.defaults.icons, {
+    paginationSwitchDown: 'fa-caret-square-down',
+    paginationSwitchUp: 'fa-caret-square-up',
+    refresh: 'fa-sync',
+    toggleOff: 'fa-toggle-off',
+    toggleOn: 'fa-toggle-on',
+    columns: 'fa-th-list',
+    detailOpen: 'fa-plus',
+    detailClose: 'fa-minus',
+    fullscreen: 'fa-arrows-alt',
+    search: 'fa-search',
+    clearSearch: 'fa-trash',
+});
 TimeAgo.addDefaultLocale(de)
 const timeAgo = new TimeAgo('de-DE')
 

--- a/web/table/table.py
+++ b/web/table/table.py
@@ -38,17 +38,31 @@ class Column:
         ``data-cell-style``.
     :param hide_if: When this callable returns true, the column returns
         an empty string when rendered.
+    :param escape: sets `data-escape`.
+        Should be set to ``False`` if you use a formatter expecting something other than a string,
+        because ``bootstrap-table``s builtin escaper forcefully casts to string otherwise.
     """
 
-    def __init__(self, title, name=None, formatter=None, width=0,
-                 cell_style=None, col_args=None, sortable=True,
-                 hide_if: Callable[[], bool] | None = lambda: False):
+    def __init__(
+        self,
+        title,
+        name=None,
+        formatter=None,
+        width=0,
+        cell_style=None,
+        col_args=None,
+        sortable=True,
+        hide_if: Callable[[], bool] | None = lambda: False,
+        escape: bool | None = None,
+    ):
         self.name = name
         self.title = title
         self.formatter = formatter if formatter is not None else False
         self.cell_style = cell_style if cell_style is not None else False
         self.width = width
         self.col_args = col_args if col_args is not None else {}
+        if escape is not None:
+            self.col_args['data-escape'] = "true" if escape else "false"
         self.sortable = sortable
         self.hide_if = hide_if
 
@@ -127,6 +141,7 @@ class custom_formatter_column:
         old_init = cls.__init__
 
         def __init__(obj, *a, **kw):
+            kw.setdefault('escape', False)
             old_init(obj, *a, formatter=self.formatter_name, **kw)
 
         cls.__init__ = __init__

--- a/web/table/table.py
+++ b/web/table/table.py
@@ -294,7 +294,7 @@ class BootstrapTable(metaclass=BootstrapTableMeta):
     table_args: TableArgs
 
     class Meta:
-        table_args = {'data-toggle': "table"}
+        table_args = {'data-toggle': "table", "data-icons-prefix": "fa"}
 
     def __init__(self, data_url, table_args=None):
         self.data_url = enforce_url_params(data_url, dict(self._enforced_url_params))

--- a/webpack.config.babel.js
+++ b/webpack.config.babel.js
@@ -131,26 +131,6 @@ export default {
                     },
                 },
             },
-            // Inject 'bootstrap' symbol into bootstrap-table`
-            // This is required because the BS5 version detection requires that:
-            // `constants/index.js` probes `bootstrap.Tooltip.VERSION`
-            // and assumes BS4 if that does not work for whatever reason.
-            {
-                test: /\.js$/,
-                use: {
-                    loader: "imports-loader",
-                    options: {
-                        // generates `const bootstrap = require('bootstrap')`
-                        type: 'commonjs',
-                        imports: {
-                            'syntax': 'single',
-                            'moduleName': 'bootstrap',
-                            'name': 'bootstrap',
-                        },
-                    },
-                },
-                include: path.join(dep, "bootstrap-table")
-            },
             // Inject jQuery import into bootstrap-datepicker locales
             {
                 test: /\.js$/,


### PR DESCRIPTION
TODO:
- [x] Fix webpack build
- [x] Fix bs-table escaping in `≥1.19.1`
- [x] Fix icon choice in bs-table `≥1.20.0`