### PR TITLE
Pydantic models for table json responses

### DIFF
--- a/pycroft/lib/host.py
+++ b/pycroft/lib/host.py
@@ -18,6 +18,7 @@ from pycroft.lib.net import get_subnets_for_room, get_free_ip, delete_ip
 from pycroft.lib.user import migrate_user_host
 from pycroft.model.facilities import Room
 from pycroft.model.host import Interface, IP, Host, SwitchPort
+from pycroft.model.port import PatchPort
 from pycroft.model.session import with_transaction, session
 from pycroft.model.user import User
 
@@ -223,8 +224,11 @@ def interface_delete(interface: Interface, processor: User) -> None:
     session.delete(interface)
 
 
-def sort_ports(ports: t.Iterable[SwitchPort]) -> list[SwitchPort]:
-    def make_sort_key(port: SwitchPort) -> int:
+TPort = t.TypeVar("TPort", bound=SwitchPort | PatchPort)
+
+
+def sort_ports(ports: t.Iterable[TPort]) -> list[TPort]:
+    def make_sort_key(port: TPort) -> int:
         return port_name_sort_key(port.name)
 
     return sorted(ports, key=make_sort_key)

--- a/pycroft/model/host.py
+++ b/pycroft/model/host.py
@@ -110,7 +110,7 @@ class Interface(IntegerIdModel):
     It has to be bound to a `UserHost`, not another kind of host (like `Switch`)
     """
 
-    name: Mapped[str] = mapped_column(String, nullable=True)
+    name: Mapped[str | None] = mapped_column(String, nullable=True)
     mac: Mapped[mac_address] = mapped_column(unique=True)
 
     host_id: Mapped[int] = mapped_column(

--- a/requirements.txt
+++ b/requirements.txt
@@ -38,3 +38,4 @@ email-validator~=1.1.1
 sentry-sdk[Flask]~=1.0.0
 -e ./deps/wtforms-widgets/
 python-dotenv~=0.21.0
+pydantic~=2.0.0

--- a/tests/factories/finance.py
+++ b/tests/factories/finance.py
@@ -39,7 +39,7 @@ class BankAccountFactory(BaseFactory):
     account_number = Faker('random_number', digits=10)
     routing_number = Faker('random_number', digits=8)
     iban = Faker('iban')
-    bic = Faker('random_number', digits=11)
+    bic = Faker("swift", length=11)
     fints_endpoint = Faker('url')
     account = SubFactory(AccountFactory, type='BANK_ASSET')
 

--- a/tests/frontend/test_task.py
+++ b/tests/frontend/test_task.py
@@ -32,5 +32,5 @@ def task_request_ctx(app):
 ])
 def test_task_object_creation(app, task: UserTask, session, task_request_ctx):
     object = task_row(task)
-    assert object['user']['title'] is not None
-    assert object['user']['href'] is not None
+    assert object.user.title is not None
+    assert object.user.href is not None

--- a/web/blueprints/facilities/__init__.py
+++ b/web/blueprints/facilities/__init__.py
@@ -60,6 +60,7 @@ from .tables import (
     PatchPortRow,
     RoomOvercrowdedRow,
 )
+from ..helpers.log_tables import LogTableRow
 
 bp = Blueprint('facilities', __name__)
 access = BlueprintAccess(bp, required_properties=['facilities_show'])
@@ -499,9 +500,12 @@ def room_show(room_id):
 
 @bp.route('/room/<int:room_id>/logs/json')
 def room_logs_json(room_id):
-    # TODO migrate this with all the other tables
-    return jsonify(items=[format_room_log_entry(entry) for entry in
-                          reversed(Room.get(room_id).log_entries)])
+    return TableResponse[LogTableRow](
+        items=[
+            format_room_log_entry(entry)
+            for entry in reversed(Room.get(room_id).log_entries)
+        ]
+    ).model_dump()
 
 
 @bp.route('/room/<int:room_id>/patchpanel/json')

--- a/web/blueprints/facilities/__init__.py
+++ b/web/blueprints/facilities/__init__.py
@@ -13,7 +13,6 @@ from collections import defaultdict
 from flask import (
     Blueprint,
     flash,
-    jsonify,
     render_template,
     url_for,
     redirect,
@@ -569,23 +568,29 @@ def room_patchpanel_json(room_id):
 @access.require('facilities_show')
 def json_levels():
     """Endpoint for the room <select> field"""
-    building_id = request.args.get('building', 0, type=int)
-    levels = session.session.query(Room.level.label('level')).filter_by(
-        building_id=building_id).order_by(Room.level).distinct()
-    return jsonify(dict(items=[entry.level for entry in levels]))
+    building_id = request.args.get("building", 0, type=int)
+    levels = (
+        session.session.query(Room.level.label("level"))
+        .filter_by(building_id=building_id)
+        .order_by(Room.level)
+        .distinct()
+    )
+    return {"items": [entry.level for entry in levels]}
 
 
 @bp.route('/json/rooms')
 @access.require('facilities_show')
 def json_rooms():
     """Endpoint for the room <select> field"""
-    building_id = request.args.get('building', 0, type=int)
-    level = request.args.get('level', 0, type=int)
-    rooms = session.session.query(
-        Room.number.label("room_num")).filter_by(
-        building_id=building_id, level=level).order_by(
-        Room.number).distinct()
-    return jsonify(dict(items=[entry.room_num for entry in rooms]))
+    building_id = request.args.get("building", 0, type=int)
+    level = request.args.get("level", 0, type=int)
+    rooms = (
+        session.session.query(Room.number.label("room_num"))
+        .filter_by(building_id=building_id, level=level)
+        .order_by(Room.number)
+        .distinct()
+    )
+    return {"items": [entry.room_num for entry in rooms]}
 
 
 @bp.route('/overcrowded', defaults={'building_id': None})

--- a/web/blueprints/facilities/__init__.py
+++ b/web/blueprints/facilities/__init__.py
@@ -628,11 +628,11 @@ def addresses(type):
     try:
         entity = get_address_entity(type)
     except ValueError as e:
-        return jsonify(errors=[e.args[0]]), 404
+        return {"errors": [e.args[0]]}, 404
 
     query: str = request.args.get('query', '').replace('%', '%%')
     limit: int = request.args.get('limit', 10, type=int)
 
     address_q = address_entity_search_query(query, entity, session.session, limit)
 
-    return jsonify(items=[str(row[0]) for row in address_q.all()])
+    return {"items": [str(row[0]) for row in address_q.all()]}

--- a/web/blueprints/facilities/__init__.py
+++ b/web/blueprints/facilities/__init__.py
@@ -44,7 +44,7 @@ from web.blueprints.access import BlueprintAccess
 from web.blueprints.facilities.forms import (
     RoomLogEntry, PatchPortForm, CreateRoomForm, EditRoomForm)
 from web.blueprints.helpers.log import format_room_log_entry
-from web.blueprints.helpers.user import user_button, user_btn_response
+from web.blueprints.helpers.user import user_btn_response
 from web.blueprints.navigation import BlueprintNavigation
 from web.table.table import TableResponse, LinkColResponse, BtnColResponse
 from .address import get_address_entity, address_entity_search_query
@@ -482,19 +482,24 @@ def room_show(room_id):
     patch_port_table = PatchPortTable(data_url=url_for(".room_patchpanel_json", room_id=room.id),
                                       room_id=room_id)
 
-    return render_template('facilities/room_show.html',
-                           page_title=f"Raum {room.short_name}",
-                           room=room,
-                           ports=room.patch_ports,
-                           user_buttons=list(map(user_button, room.users)),
-                           user_histories=[(user_button(room_history_entry.user),
-                                            room_history_entry.active_during.begin,
-                                            room_history_entry.active_during.end)
-                                           for room_history_entry
-                                           in room.room_history_entries],
-                           room_log_table=room_log_table,
-                           patch_port_table=patch_port_table,
-                           form=form, )
+    return render_template(
+        "facilities/room_show.html",
+        page_title=f"Raum {room.short_name}",
+        room=room,
+        ports=room.patch_ports,
+        user_buttons=[user_btn_response(user).model_dump() for user in room.users],
+        user_histories=[
+            (
+                user_btn_response(room_history_entry.user).model_dump(),
+                room_history_entry.active_during.begin,
+                room_history_entry.active_during.end,
+            )
+            for room_history_entry in room.room_history_entries
+        ],
+        room_log_table=room_log_table,
+        patch_port_table=patch_port_table,
+        form=form,
+    )
 
 
 @bp.route('/room/<int:room_id>/logs/json')

--- a/web/blueprints/facilities/__init__.py
+++ b/web/blueprints/facilities/__init__.py
@@ -44,7 +44,7 @@ from web.blueprints.access import BlueprintAccess
 from web.blueprints.facilities.forms import (
     RoomLogEntry, PatchPortForm, CreateRoomForm, EditRoomForm)
 from web.blueprints.helpers.log import format_room_log_entry
-from web.blueprints.helpers.user import user_btn_response
+from web.blueprints.helpers.user import user_button
 from web.blueprints.navigation import BlueprintNavigation
 from web.table.table import TableResponse, LinkColResponse, BtnColResponse
 from .address import get_address_entity, address_entity_search_query
@@ -323,7 +323,7 @@ def building_level_rooms_json(level, building_id=None, building_shortname=None):
                     href=url_for(".room_show", room_id=room.id),
                     title=f"{level:02d} - {room.number}",
                 ),
-                inhabitants=[user_btn_response(i) for i in inhabitants],
+                inhabitants=[user_button(i) for i in inhabitants],
             )
             for room, inhabitants in level_inhabitants.items()
         ]
@@ -487,10 +487,10 @@ def room_show(room_id):
         page_title=f"Raum {room.short_name}",
         room=room,
         ports=room.patch_ports,
-        user_buttons=[user_btn_response(user).model_dump() for user in room.users],
+        user_buttons=[user_button(user).model_dump() for user in room.users],
         user_histories=[
             (
-                user_btn_response(room_history_entry.user).model_dump(),
+                user_button(room_history_entry.user).model_dump(),
                 room_history_entry.active_during.begin,
                 room_history_entry.active_during.end,
             )
@@ -630,7 +630,7 @@ def overcrowded_json(building_id):
                         "facilities.room_show", room_id=inhabitants[0].room.id
                     ),
                 ),
-                inhabitants=[user_btn_response(user) for user in inhabitants],
+                inhabitants=[user_button(user) for user in inhabitants],
             )
             for inhabitants in get_overcrowded_rooms(building_id).values()
         ]

--- a/web/blueprints/facilities/tables.py
+++ b/web/blueprints/facilities/tables.py
@@ -51,6 +51,7 @@ class BuildingLevelRoomRow(BaseModel):
 
 
 class RoomLogTable(BootstrapTable):
+    """Like a log table, just with absolute date column"""
     created_at = DateColumn("Erstellt um")
     user = LinkColumn("Nutzer")
     message = Column("Nachricht")

--- a/web/blueprints/facilities/tables.py
+++ b/web/blueprints/facilities/tables.py
@@ -45,6 +45,11 @@ class BuildingLevelRoomTable(BootstrapTable):
         )
 
 
+class BuildingLevelRoomRow(BaseModel):
+    room: LinkColResponse
+    inhabitants: list[BtnColResponse]
+
+
 class RoomLogTable(BootstrapTable):
     created_at = DateColumn("Erstellt um")
     user = LinkColumn("Nutzer")
@@ -57,6 +62,11 @@ class RoomOvercrowdedTable(BootstrapTable):
 
     class Meta:
         table_args = {'data-sort-name': 'room'}
+
+
+class RoomOvercrowdedRow(BaseModel):
+    room: LinkColResponse
+    inhabitants: list[BtnColResponse]
 
 
 class PatchPortTable(BootstrapTable):
@@ -82,3 +92,11 @@ class PatchPortTable(BootstrapTable):
             return
         href = url_for(".patch_port_create", switch_room_id=self.room_id)
         return button_toolbar("Patch-Port", href)
+
+
+class PatchPortRow(BaseModel):
+    name: str
+    room: LinkColResponse
+    switch_port: LinkColResponse
+    edit_link: BtnColResponse
+    delete_link: BtnColResponse

--- a/web/blueprints/facilities/tables.py
+++ b/web/blueprints/facilities/tables.py
@@ -1,13 +1,29 @@
 from flask import url_for
+from pydantic import BaseModel
 
-from web.table.table import BootstrapTable, Column, LinkColumn, \
-    button_toolbar, toggle_button_toolbar, BtnColumn, MultiBtnColumn, DateColumn
+from web.table.table import (
+    BootstrapTable,
+    Column,
+    LinkColumn,
+    button_toolbar,
+    toggle_button_toolbar,
+    BtnColumn,
+    MultiBtnColumn,
+    DateColumn,
+    LinkColResponse,
+    BtnColResponse,
+)
 from web.blueprints.infrastructure.tables import no_inf_change
 
 
 class SiteTable(BootstrapTable):
     site = LinkColumn("Site")
     buildings = MultiBtnColumn("Buildings")
+
+
+class SiteRow(BaseModel):
+    site: LinkColResponse
+    buildings: list[BtnColResponse]
 
 
 class BuildingLevelRoomTable(BootstrapTable):

--- a/web/blueprints/finance/__init__.py
+++ b/web/blueprints/finance/__init__.py
@@ -112,7 +112,6 @@ from web.blueprints.helpers.api import json_agg_core
 from web.blueprints.helpers.exception import handle_errors
 from web.blueprints.navigation import BlueprintNavigation
 from web.table.table import (
-    date_format,
     TableResponse,
     date_format_pydantic,
     BtnColResponse,

--- a/web/blueprints/finance/__init__.py
+++ b/web/blueprints/finance/__init__.py
@@ -669,7 +669,7 @@ def balance_json(account_id):
                     .where(Split.account_id == account_id))
 
     res = session.execute(json_agg_core(balance_json)).first()[0]
-    return jsonify(items=res)
+    return {"items": res}
 
 
 @bp.route('/accounts/<int:account_id>')
@@ -1426,14 +1426,17 @@ def json_accounts_user_search():
             func.lower(User.login).like(func.lower(f"%{query}%")),
             cast(User.id, Text).like(f"{query}%"))
     ).all()
-    accounts = [
-        {"account_id": account_id,
-         "user_id": user_id,
-         "user_login": user_login,
-         "user_name": user_name}
-        for account_id, user_id, user_login, user_name in results
-    ]
-    return jsonify(accounts=accounts)
+    return {
+        "accounts": [
+            {
+                "account_id": account_id,
+                "user_id": user_id,
+                "user_login": user_login,
+                "user_name": user_name,
+            }
+            for account_id, user_id, user_login, user_name in results
+        ]
+    }
 
 
 @bp.route('/membership_fees/payments_in_default_csv')

--- a/web/blueprints/finance/__init__.py
+++ b/web/blueprints/finance/__init__.py
@@ -66,19 +66,50 @@ from pycroft.model.session import session, utcnow
 from pycroft.model.user import User
 from web.blueprints.access import BlueprintAccess
 from web.blueprints.finance.forms import (
-    AccountCreateForm, BankAccountCreateForm, BankAccountActivityEditForm,
-    BankAccountActivitiesImportForm, TransactionCreateForm,
-    MembershipFeeCreateForm, MembershipFeeEditForm, FeeApplyForm,
-    HandlePaymentsInDefaultForm, FixMT940Form, BankAccountActivityReadForm,
-    BankAccountActivitiesImportManualForm, ConfirmPaymentReminderMail)
-from web.blueprints.finance.tables import FinanceTable, FinanceTableSplitted, \
-    MembershipFeeTable, UsersDueTable, BankAccountTable, \
-    BankAccountActivityTable, TransactionTable, ImportErrorTable, \
-    UnconfirmedTransactionsTable
+    AccountCreateForm,
+    BankAccountCreateForm,
+    BankAccountActivityEditForm,
+    BankAccountActivitiesImportForm,
+    TransactionCreateForm,
+    MembershipFeeCreateForm,
+    MembershipFeeEditForm,
+    FeeApplyForm,
+    HandlePaymentsInDefaultForm,
+    FixMT940Form,
+    BankAccountActivityReadForm,
+    BankAccountActivitiesImportManualForm,
+    ConfirmPaymentReminderMail,
+)
+from web.blueprints.finance.tables import (
+    FinanceTable,
+    FinanceTableSplitted,
+    MembershipFeeTable,
+    UsersDueTable,
+    BankAccountTable,
+    BankAccountActivityTable,
+    TransactionTable,
+    ImportErrorTable,
+    UnconfirmedTransactionsTable,
+    BankAccountRow,
+    BankAccountActivityRow,
+    ImportErrorRow,
+    TransactionSplitResponse,
+    TransactionSplitRow,
+    UnconfirmedTransactionsRow,
+    UsersDueRow,
+    ColoredColResponse,
+    MembershipFeeRow,
+)
 from web.blueprints.helpers.api import json_agg_core
 from web.blueprints.helpers.exception import handle_errors
 from web.blueprints.navigation import BlueprintNavigation
-from web.table.table import date_format
+from web.table.table import (
+    date_format,
+    TableResponse,
+    date_format_pydantic,
+    BtnColResponse,
+    LinkColResponse,
+)
 from web.template_filters import date_filter, money_filter, datetime_filter
 from web.template_tests import privilege_check
 
@@ -110,83 +141,84 @@ def bank_accounts_list():
 
 @bp.route('/bank-accounts/list/json')
 def bank_accounts_list_json():
-    return jsonify(
+    return TableResponse[BankAccountRow](
         items=[
-            {
-                "name": bank_account.name,
-                "bank": bank_account.bank,
-                "ktonr": bank_account.account_number,
-                "blz": bank_account.routing_number,
-                "iban": bank_account.iban,
-                "bic": bank_account.bic,
-                "kto": BankAccountTable.kto.value(
+            BankAccountRow(
+                name=bank_account.name,
+                bank=bank_account.bank,
+                iban=bank_account.iban,
+                bic=bank_account.bic,
+                kto=BtnColResponse(
                     href=url_for(".accounts_show", account_id=bank_account.account_id),
                     title="Konto anzeigen",
                     btn_class="btn-primary",
                 ),
-                "balance": money_filter(bank_account.balance),
-                "last_imported_at": (
+                balance=money_filter(bank_account.balance),
+                last_imported_at=(
                     str(datetime.date(i))
                     if (i := bank_account.last_imported_at) is not None
                     else "nie"
                 ),
-            }
+            )
             for bank_account in get_all_bank_accounts(session)
         ]
-    )
+    ).model_dump()
 
 
 @bp.route('/bank-accounts/activities/json')
 def bank_accounts_activities_json():
-    def actions(activity_id):
-        return [BankAccountActivityTable.actions.single_value(
-            href=url_for('.bank_account_activities_edit', activity_id=activity_id),
-            title='',
-            btn_class='btn-primary',
-            icon='fa-edit'
-        )]
+    def actions(activity_id) -> list[BtnColResponse]:
+        return [
+            BtnColResponse(
+                href=url_for(".bank_account_activities_edit", activity_id=activity_id),
+                title="",
+                btn_class="btn-primary",
+                icon="fa-edit",
+            )
+        ]
 
     activity_q = get_unassigned_bank_account_activities(session)
 
-    return jsonify(
+    return TableResponse[BankAccountActivityRow](
         items=[
-            {
-                "bank_account": activity.bank_account.name,
-                "name": activity.other_name,
-                "valid_on": date_format(activity.valid_on, formatter=date_filter),
-                "imported_at": date_format(activity.imported_at, formatter=date_filter),
-                "reference": activity.reference,
-                "amount": activity.amount,
-                "iban": activity.other_account_number,
-                "actions": actions(activity.id),
-                "row_positive": activity.amount >= 0,
-            }
+            BankAccountActivityRow(
+                bank_account=activity.bank_account.name,
+                name=activity.other_name,
+                valid_on=date_format_pydantic(activity.valid_on, formatter=date_filter),
+                imported_at=date_format_pydantic(
+                    activity.imported_at, formatter=date_filter
+                ),
+                reference=activity.reference,
+                amount=activity.amount,
+                iban=activity.other_account_number,
+                actions=actions(activity.id),
+                row_positive=activity.amount >= 0,
+            )
             for activity in activity_q
         ]
-    )
+    ).model_dump()
 
 
 @bp.route('/bank-accounts/import/errors/json')
 def bank_accounts_errors_json():
-    T = ImportErrorTable
-    return jsonify(
+    return TableResponse[ImportErrorRow](
         items=[
-            {
-                "name": error.bank_account.name,
-                "fix": T.fix.value(
+            ImportErrorRow(
+                name=error.bank_account.name,
+                fix=BtnColResponse(
                     href=url_for(".fix_import_error", error_id=error.id),
                     title="korrigieren",
                     btn_class="btn-primary",
                 ),
-                "imported_at": (
+                imported_at=(
                     str(datetime.date(i))
                     if (i := error.imported_at) is not None
                     else "nie"
                 ),
-            }
+            )
             for error in get_all_mt940_errors(session)
         ]
-    )
+    ).model_dump()
 
 
 from contextlib import contextmanager
@@ -762,6 +794,7 @@ def accounts_show_json(account_id):
 
     items = {'total': total, 'rows': rows}
 
+    # TODO create pydantic model for this
     return jsonify(
         name=account.name,
         items=items
@@ -789,17 +822,20 @@ def transactions_show(transaction_id):
 @bp.route('/transactions/<int:transaction_id>/json')
 def transactions_show_json(transaction_id):
     transaction = Transaction.get(transaction_id)
-    return jsonify(
+    return TransactionSplitResponse(
         description=transaction.description,
         items=[
-            {
-                'account': TransactionTable.account.value(
+            TransactionSplitRow(
+                account=LinkColResponse(
                     href=url_for(".accounts_show", account_id=split.account_id),
                     title=localized(split.account.name, {int: {'insert_commas': False}})
                 ),
-                'amount': money_filter(split.amount),
-                'row_positive': split.amount > 0
-            } for split in transaction.splits])
+                amount=money_filter(split.amount),
+                row_positive=split.amount > 0,
+            )
+            for split in transaction.splits
+        ],
+    ).model_dump()
 
 
 @bp.route('/transactions/unconfirmed')
@@ -812,70 +848,96 @@ def transactions_unconfirmed():
             data_url=url_for(".transactions_unconfirmed_json"))
     )
 
-@bp.route('/transactions/unconfirmed/json')
-def transactions_unconfirmed_json():
-    transactions = Transaction.q.filter_by(confirmed=False).order_by(Transaction.posted_at).limit(
-        100).all()
 
-    items = []
-    T = UnconfirmedTransactionsTable
+def _iter_transaction_buttons(bank_acc_act, transaction) -> t.Iterator[BtnColResponse]:
+    if not privilege_check(current_user, "finance_change"):
+        return
 
-    for transaction in transactions:
-        user_account = next(
-            (a for a in transaction.accounts if a.type == "USER_ASSET"), None
+    if bank_acc_act is not None:
+        yield BtnColResponse(
+            href=url_for(".bank_account_activities_edit", activity_id=bank_acc_act.id),
+            title="Bankbewegung",
+            icon="fa-credit-card",
+            btn_class="btn-info btn-sm",
+            new_tab=True,
         )
-        bank_acc_act = BankAccountActivity.q.filter_by(
-            transaction_id=transaction.id
-        ).first()
+    yield BtnColResponse(
+        href=url_for(".transaction_confirm", transaction_id=transaction.id),
+        title="Bestätigen",
+        icon="fa-check",
+        btn_class="btn-success btn-sm",
+    )
+    yield BtnColResponse(
+        href=url_for(".transaction_delete", transaction_id=transaction.id),
+        title="Löschen",
+        icon="fa-trash",
+        btn_class="btn-danger btn-sm",
+    )
 
-        items.append(
-            {
-                "id": transaction.id,
-                "description": T.description.value(
-                    href=url_for(".transactions_show", transaction_id=transaction.id),
-                    title=transaction.description,
-                    new_tab=True,
-                    glyphicon='fa-external-link-alt'
-                ),
-                'user': T.user.value(
-                    href=url_for("user.user_show", user_id=user_account.user.id),
-                    title="{} ({})".format(user_account.user.name,
-                                           encode_type2_user_id(user_account.user.id)),
-                    new_tab=True
-                ) if user_account else None,
-                'room': user_account.user.room.short_name if user_account and user_account.user.room else None,
-                'author': T.author.value(
-                    href=url_for("user.user_show", user_id=transaction.author.id),
-                    title=transaction.author.name,
-                    new_tab=True
-                ),
-                'date': date_format(transaction.posted_at, formatter=date_filter),
-                'amount': money_filter(transaction.amount),
-                'actions': [
-                    T.actions.single_value(
-                        href=url_for(".bank_account_activities_edit",
-                                     activity_id=bank_acc_act.id),
-                        title='Bankbewegung', icon='fa-credit-card',
-                        btn_class='btn-info btn-sm',
-                        new_tab=True
-                    ) if bank_acc_act is not None else {},
-                    T.actions.single_value(
-                        href=url_for(".transaction_confirm",
-                                     transaction_id=transaction.id), title='Bestätigen',
-                        icon='fa-check', btn_class='btn-success btn-sm'
-                    ),
-                    T.actions.single_value(
-                        href=url_for(".transaction_delete",
-                                     transaction_id=transaction.id), title='Löschen',
-                        icon='fa-trash',
-                        btn_class='btn-danger btn-sm'
-                    )
-                ]
-                if privilege_check(current_user, "finance_change")
-                else [],
-            })
 
-    return jsonify(items=items)
+def _format_transaction_row(
+    transaction: Transaction,
+    user_account: Account,
+    bank_acc_act: BankAccountActivity,
+) -> UnconfirmedTransactionsRow:
+    return UnconfirmedTransactionsRow(
+        id=transaction.id,
+        description=LinkColResponse(
+            href=url_for(".transactions_show", transaction_id=transaction.id),
+            title=transaction.description,
+            new_tab=True,
+            glyphicon="fa-external-link-alt",
+        ),
+        user=LinkColResponse(
+            href=url_for("user.user_show", user_id=user_account.user.id),
+            title="{} ({})".format(
+                user_account.user.name,
+                encode_type2_user_id(user_account.user.id),
+            ),
+            new_tab=True,
+        )
+        if user_account
+        else None,
+        room=user_account.user.room.short_name
+        if user_account and user_account.user.room
+        else None,
+        author=LinkColResponse(
+            href=url_for("user.user_show", user_id=transaction.author.id),
+            title=transaction.author.name,
+            new_tab=True,
+        ),
+        date=date_format_pydantic(transaction.posted_at, formatter=date_filter),
+        amount=money_filter(transaction.amount),
+        actions=list(_iter_transaction_buttons(bank_acc_act, transaction)),
+    )
+
+
+@bp.route("/transactions/unconfirmed/json")
+def transactions_unconfirmed_json():
+    # TODO extract transaction fetch (with user/bank account) to lib function
+    transactions = (
+        Transaction.q.filter_by(confirmed=False)
+        .order_by(Transaction.posted_at)
+        .limit(100)
+        .all()
+    )
+    return TableResponse[UnconfirmedTransactionsRow](
+        items=[
+            _format_transaction_row(
+                transaction,
+                user_account=next(
+                    (a for a in transaction.accounts if a.type == "USER_ASSET"), None
+                ),
+                bank_acc_act=(
+                    # TODO do eager load
+                    BankAccountActivity.q.filter_by(
+                        transaction_id=transaction.id
+                    ).first()
+                ),
+            )
+            for transaction in transactions
+        ]
+    ).model_dump()
 
 
 @bp.route('/transaction/<int:transaction_id>/confirm', methods=['GET', 'POST'])
@@ -1132,26 +1194,30 @@ def membership_fee_users_due_json(fee_id):
     affected_users = post_transactions_for_membership_fee(
         fee, current_user, simulate=True)
 
-    fee_amount = {'value': str(fee.regular_fee) + '€',
-                  'is_positive': (fee.regular_fee < 0)}
     fee_description = localized(
         finance.membership_fee_description.format(fee_name=fee.name).to_json())
 
-    T = UsersDueTable
-    return jsonify(items=[{
-        'user_id': user['id'],
-        'user': T.user.value(
-            title=str(user['name']),
-            href=url_for("user.user_show", user_id=user['id'])
-        ),
-        'amount': fee_amount,
-        'description': fee_description,
-        'valid_on': fee.ends_on,
-        'fee_account_id': T.fee_account_id.value(
-            title=str(user['fee_account_id']),
-            href=url_for(".accounts_show", account_id=user['fee_account_id'])
-        ),
-    } for user in affected_users])
+    return TableResponse[UsersDueRow](
+        items=[
+            UsersDueRow(
+                user_id=user["id"],
+                user=LinkColResponse(
+                    title=str(user["name"]),
+                    href=url_for("user.user_show", user_id=user["id"]),
+                ),
+                amount=ColoredColResponse(
+                    value=str(fee.regular_fee) + "€", is_positive=(fee.regular_fee < 0)
+                ),
+                description=fee_description,
+                valid_on=str(fee.ends_on),  # TODO use proper date column
+                fee_account_id=LinkColResponse(
+                    title=str(user["fee_account_id"]),
+                    href=url_for(".accounts_show", account_id=user["fee_account_id"]),
+                ),
+            )
+            for user in affected_users
+        ]
+    ).model_dump()
 
 
 @bp.route("/membership_fees", methods=['GET', 'POST'])
@@ -1164,36 +1230,50 @@ def membership_fees():
 @bp.route("/membership_fees/json")
 @access.require('finance_change')
 def membership_fees_json():
-    T = MembershipFeeTable
-    return jsonify(items=[
-        {
-            'name': localized(membership_fee.name),
-            'regular_fee': money_filter(
-                membership_fee.regular_fee),
-            'payment_deadline': membership_fee.payment_deadline.days,
-            'payment_deadline_final': membership_fee.payment_deadline_final.days,
-            'begins_on': date_format(membership_fee.begins_on, formatter=date_filter),
-            'ends_on': date_format(membership_fee.ends_on, formatter=date_filter),
-            'actions': [
-                T.actions.single_value(
-                    href=url_for(".transactions_all",
-                                 filter="all",
-                                 after=membership_fee.begins_on,
-                                 before=membership_fee.ends_on),
-                    title='Finanzübersicht',
-                    icon='fa-euro-sign', btn_class='btn-success btn-sm'
+    return TableResponse[MembershipFeeRow](
+        items=[
+            MembershipFeeRow(
+                name=localized(membership_fee.name),
+                regular_fee=money_filter(membership_fee.regular_fee),
+                payment_deadline=membership_fee.payment_deadline.days,
+                payment_deadline_final=membership_fee.payment_deadline_final.days,
+                begins_on=date_format_pydantic(
+                    membership_fee.begins_on, formatter=date_filter
                 ),
-                T.actions.single_value(
-                    href=url_for(".membership_fee_book", fee_id=membership_fee.id),
-                    title='Buchen', icon='fa-book', btn_class='btn-warning btn-sm'
+                ends_on=date_format_pydantic(
+                    membership_fee.ends_on, formatter=date_filter
                 ),
-                T.actions.single_value(
-                    href=url_for(".membership_fee_edit", fee_id=membership_fee.id),
-                    title='Bearbeiten', icon='fa-edit', btn_class='btn-primary btn-sm'
-                )
-            ]
-        } for membership_fee in
-        MembershipFee.q.order_by(MembershipFee.begins_on.desc()).all()])
+                actions=[
+                    BtnColResponse(
+                        href=url_for(
+                            ".transactions_all",
+                            filter="all",
+                            after=membership_fee.begins_on,
+                            before=membership_fee.ends_on,
+                        ),
+                        title="Finanzübersicht",
+                        icon="fa-euro-sign",
+                        btn_class="btn-success btn-sm",
+                    ),
+                    BtnColResponse(
+                        href=url_for(".membership_fee_book", fee_id=membership_fee.id),
+                        title="Buchen",
+                        icon="fa-book",
+                        btn_class="btn-warning btn-sm",
+                    ),
+                    BtnColResponse(
+                        href=url_for(".membership_fee_edit", fee_id=membership_fee.id),
+                        title="Bearbeiten",
+                        icon="fa-edit",
+                        btn_class="btn-primary btn-sm",
+                    ),
+                ],
+            )
+            for membership_fee in MembershipFee.q.order_by(
+                MembershipFee.begins_on.desc()
+            ).all()
+        ]
+    ).model_dump()
 
 
 @bp.route('/membership_fee/create', methods=("GET", "POST"))

--- a/web/blueprints/finance/__init__.py
+++ b/web/blueprints/finance/__init__.py
@@ -113,7 +113,7 @@ from web.blueprints.helpers.exception import handle_errors
 from web.blueprints.navigation import BlueprintNavigation
 from web.table.table import (
     TableResponse,
-    date_format_pydantic,
+    date_format,
     BtnColResponse,
     LinkColResponse,
 )
@@ -191,10 +191,8 @@ def bank_accounts_activities_json():
             BankAccountActivityRow(
                 bank_account=activity.bank_account.name,
                 name=activity.other_name,
-                valid_on=date_format_pydantic(activity.valid_on, formatter=date_filter),
-                imported_at=date_format_pydantic(
-                    activity.imported_at, formatter=date_filter
-                ),
+                valid_on=date_format(activity.valid_on, formatter=date_filter),
+                imported_at=date_format(activity.imported_at, formatter=date_filter),
                 reference=activity.reference,
                 amount=activity.amount,
                 iban=activity.other_account_number,
@@ -907,7 +905,7 @@ def _format_transaction_row(
             title=transaction.author.name,
             new_tab=True,
         ),
-        date=date_format_pydantic(transaction.posted_at, formatter=date_filter),
+        date=date_format(transaction.posted_at, formatter=date_filter),
         amount=money_filter(transaction.amount),
         actions=list(_iter_transaction_buttons(bank_acc_act, transaction)),
     )
@@ -1238,12 +1236,8 @@ def membership_fees_json():
                 regular_fee=money_filter(membership_fee.regular_fee),
                 payment_deadline=membership_fee.payment_deadline.days,
                 payment_deadline_final=membership_fee.payment_deadline_final.days,
-                begins_on=date_format_pydantic(
-                    membership_fee.begins_on, formatter=date_filter
-                ),
-                ends_on=date_format_pydantic(
-                    membership_fee.ends_on, formatter=date_filter
-                ),
+                begins_on=date_format(membership_fee.begins_on, formatter=date_filter),
+                ends_on=date_format(membership_fee.ends_on, formatter=date_filter),
                 actions=[
                     BtnColResponse(
                         href=url_for(

--- a/web/blueprints/finance/tables.py
+++ b/web/blueprints/finance/tables.py
@@ -251,7 +251,7 @@ class BankAccountActivityRow(BaseModel):
     imported_at: DateColResponse
     reference: str
     iban: str
-    amount: Decimal
+    amount: Decimal | int
     actions: list[BtnColResponse]
     row_positive: bool
 

--- a/web/blueprints/finance/tables.py
+++ b/web/blueprints/finance/tables.py
@@ -106,6 +106,14 @@ class FinanceTable(BootstrapTable):
         yield "</tfoot>"
 
 
+class FinanceRow(BaseModel):
+    posted_at: str
+    valid_on: str
+    description: LinkColResponse
+    amount: ColoredColResponse
+    row_positive: bool
+
+
 class FinanceTableSplitted(FinanceTable, SplittedTable):
     class Meta:
         table_args = {

--- a/web/blueprints/helpers/log.py
+++ b/web/blueprints/helpers/log.py
@@ -15,7 +15,7 @@ from hades_logs import RadiusLogEntry
 from pycroft.helpers.i18n import Message
 from pycroft.model.logging import LogEntry
 from web.table.table import (
-    datetime_format_pydantic,
+    datetime_format,
     UserColResponseNative,
     UserColResponsePlain,
 )
@@ -26,9 +26,7 @@ from web.template_filters import datetime_filter
 
 def format_log_entry(entry: LogEntry, log_type: LogType) -> LogTableRow:
     return LogTableRow(
-        created_at=datetime_format_pydantic(
-            entry.created_at, formatter=datetime_filter
-        ),
+        created_at=datetime_format(entry.created_at, formatter=datetime_filter),
         user=UserColResponseNative(
             title=entry.author.name,
             href=url_for("user.user_show", user_id=entry.author.id),
@@ -76,7 +74,7 @@ def format_hades_log_entry(interface: str, entry: RadiusLogEntry) -> LogTableRow
     date = entry.time
     desc = radius_description(interface, entry)
     return LogTableRow(
-        created_at=datetime_format_pydantic(date, formatter=datetime_filter),
+        created_at=datetime_format(date, formatter=datetime_filter),
         user=UserColResponsePlain(title="Radius"),
         message=desc,
         type="hades",
@@ -86,7 +84,7 @@ def format_hades_log_entry(interface: str, entry: RadiusLogEntry) -> LogTableRow
 def format_custom_hades_message(message: str) -> LogTableRow:
     date = datetime.now(tz=timezone.utc)
     return LogTableRow(
-        created_at=datetime_format_pydantic(date, formatter=datetime_filter),
+        created_at=datetime_format(date, formatter=datetime_filter),
         user=UserColResponsePlain(title="Radius"),
         message=message,
         type="hades",

--- a/web/blueprints/helpers/log_tables.py
+++ b/web/blueprints/helpers/log_tables.py
@@ -1,0 +1,57 @@
+#  Copyright (c) 2023. The Pycroft Authors. See the AUTHORS file.
+#  This file is part of the Pycroft project and licensed under the terms of
+#  the Apache License, Version 2.0. See the LICENSE file for details
+
+import typing as t
+
+from pydantic import BaseModel
+
+from web.table.table import (
+    BootstrapTable,
+    RelativeDateColumn,
+    Column,
+    UserColumn,
+    DateColResponse,
+    UserColResponse,
+)
+
+
+class RefreshableTableMixin:
+    """A mixin class showing the refresh button by default.
+
+    In :py:meth:`__init__`s ``table_args`` argument, a default of
+    ``{'data-show-refresh': "true"}`` is established.
+    """
+
+    def __init__(self, *a, **kw):
+        table_args = kw.pop("table_args", {})
+        table_args.setdefault("data-show-refresh", "true")
+        kw["table_args"] = table_args
+        super().__init__(*a, **kw)
+
+
+class LogTableExtended(RefreshableTableMixin, BootstrapTable):
+    """A table for displaying logs, with a ``type`` column"""
+
+    created_at = RelativeDateColumn("Erstellt um", width=2)
+    type_ = Column("Logtyp", name="type", sortable=False)
+    user = UserColumn("Nutzer")
+    message = Column("Nachricht", formatter="table.withMagicLinksFormatter")
+
+
+class LogTableSpecific(RefreshableTableMixin, BootstrapTable):
+    """A table for displaying logs"""
+
+    created_at = RelativeDateColumn("Erstellt um", width=2)
+    user = UserColumn("Nutzer")
+    message = Column("Nachricht", formatter="table.withMagicLinksFormatter")
+
+
+LogType = t.Literal["user", "room", "hades", "task", "all"]
+
+
+class LogTableRow(BaseModel):
+    created_at: DateColResponse
+    type: LogType | None
+    user: UserColResponse
+    message: str

--- a/web/blueprints/helpers/user.py
+++ b/web/blueprints/helpers/user.py
@@ -79,13 +79,6 @@ def user_btn_response(user: User) -> BtnColResponse:
     )
 
 
-def user_button(user: User) -> dict:
-    import warnings
-
-    warnings.warn("use user_btn_response instead", DeprecationWarning, stacklevel=2)
-    return user_btn_response(user).model_dump()
-
-
 def get_user_or_404(user_id: int) -> User | NoReturn:
     user = User.get(user_id)
     if user is None:

--- a/web/blueprints/helpers/user.py
+++ b/web/blueprints/helpers/user.py
@@ -67,8 +67,7 @@ def user_btn_style(user):
     return btn_class, glyphicons, tooltip
 
 
-def user_btn_response(user: User) -> BtnColResponse:
-    # TODO rename this to `user_button` after adoption
+def user_button(user: User) -> BtnColResponse:
     btn_class, glyphicons, tooltip = user_btn_style(user)
     return BtnColResponse(
         href=url_for("user.user_show", user_id=user.id),

--- a/web/blueprints/helpers/user.py
+++ b/web/blueprints/helpers/user.py
@@ -4,6 +4,7 @@ from flask import url_for, flash, abort
 from flask_login import current_user
 
 from pycroft.model.user import User, PreMember
+from web.table.table import BtnColResponse
 
 
 def user_btn_style(user):
@@ -66,15 +67,23 @@ def user_btn_style(user):
     return btn_class, glyphicons, tooltip
 
 
-def user_button(user):
+def user_btn_response(user: User) -> BtnColResponse:
+    # TODO rename this to `user_button` after adoption
     btn_class, glyphicons, tooltip = user_btn_style(user)
-    return {
-        'href': url_for("user.user_show", user_id=user.id),
-        'title': user.name,
-        'icon': glyphicons,
-        'btn_class': btn_class,
-        'tooltip': tooltip
-    }
+    return BtnColResponse(
+        href=url_for("user.user_show", user_id=user.id),
+        title=user.name,
+        icon=glyphicons,
+        btn_class=btn_class,
+        tooltip=tooltip,
+    )
+
+
+def user_button(user: User) -> dict:
+    import warnings
+
+    warnings.warn("use user_btn_response instead", DeprecationWarning, stacklevel=2)
+    return user_btn_response(user).model_dump()
 
 
 def get_user_or_404(user_id: int) -> User | NoReturn:

--- a/web/blueprints/host/__init__.py
+++ b/web/blueprints/host/__init__.py
@@ -11,7 +11,6 @@ from pycroft.lib import host as lib_host
 from pycroft.lib.net import get_subnets_for_room, get_unused_ips
 from pycroft.lib.facilities import get_room
 from pycroft.model import session
-from pycroft.model.facilities import Room
 from pycroft.model.host import Host, Interface
 from pycroft.model.user import User
 from web.blueprints.access import BlueprintAccess

--- a/web/blueprints/host/__init__.py
+++ b/web/blueprints/host/__init__.py
@@ -1,7 +1,6 @@
 import re
 
-from flask import Blueprint, flash, abort, redirect, url_for, render_template, \
-    jsonify, request
+from flask import Blueprint, flash, abort, redirect, url_for, render_template, request
 from flask_login import current_user
 from flask_wtf import FlaskForm
 from ipaddr import IPv4Address
@@ -394,5 +393,4 @@ def user_hosts_json(user_id):
 def interface_manufacturer_json(mac):
     if not re.match(mac_regex, mac):
         return abort(400)
-
-    return jsonify(manufacturer=get_interface_manufacturer(mac))
+    return {"manufacturer": get_interface_manufacturer(mac)}

--- a/web/blueprints/host/tables.py
+++ b/web/blueprints/host/tables.py
@@ -1,8 +1,14 @@
 from flask import url_for
+from pydantic import BaseModel
 
 from web.blueprints.helpers.user import no_hosts_change
-from web.table.table import BootstrapTable, Column, button_toolbar, \
-    MultiBtnColumn
+from web.table.table import (
+    BootstrapTable,
+    Column,
+    button_toolbar,
+    MultiBtnColumn,
+    BtnColResponse,
+)
 
 
 class HostTable(BootstrapTable):
@@ -36,6 +42,16 @@ class HostTable(BootstrapTable):
 
         href = url_for("host.host_create", user_id=self.user_id)
         return button_toolbar("Host", href)
+
+
+class HostRow(BaseModel):
+    name: str | None
+    switch: str | None
+    port: str | None
+    actions: list[BtnColResponse]
+    interfaces_table_link: str
+    interface_create_link: str
+    id: int
 
 
 class InterfaceTable(BootstrapTable):

--- a/web/blueprints/host/tables.py
+++ b/web/blueprints/host/tables.py
@@ -70,3 +70,12 @@ class InterfaceTable(BootstrapTable):
 
         super().__init__(*a, **kw)
         self.host_id = host_id
+
+
+class InterfaceRow(BaseModel):
+    id: int  # TODO is this used?
+    host: str | None
+    name: str | None
+    mac: str
+    ips: str
+    actions: list[BtnColResponse]

--- a/web/blueprints/infrastructure/__init__.py
+++ b/web/blueprints/infrastructure/__init__.py
@@ -99,7 +99,7 @@ def switches_json():
             SwitchRow(
                 id=switch.host_id,
                 name=LinkColResponse(
-                    title=switch.host.name,
+                    title=switch.host.name or "<unnamed>",
                     href=url_for(".switch_show", switch_id=switch.host_id),
                 ),
                 ip=str(switch.management_ip),

--- a/web/blueprints/infrastructure/__init__.py
+++ b/web/blueprints/infrastructure/__init__.py
@@ -10,8 +10,7 @@
     :copyright: (c) 2012 by AG DSN.
 """
 
-from flask import (
-    Blueprint, abort, flash, jsonify, redirect, render_template, url_for)
+from flask import Blueprint, abort, flash, redirect, render_template, url_for
 from flask_login import current_user
 from flask_wtf import FlaskForm as Form
 from ipaddr import IPAddress
@@ -32,7 +31,16 @@ from web.blueprints.access import BlueprintAccess
 from web.blueprints.infrastructure.forms import SwitchForm, SwitchPortForm
 from web.blueprints.navigation import BlueprintNavigation
 from web.table.table import LinkColResponse, TableResponse, BtnColResponse
-from .tables import SubnetTable, SwitchTable, VlanTable, PortTable, SwitchRow
+from .tables import (
+    SubnetTable,
+    SwitchTable,
+    VlanTable,
+    PortTable,
+    SwitchRow,
+    PortRow,
+    VlanRow,
+    SubnetRow,
+)
 
 bp = Blueprint('infrastructure', __name__)
 access = BlueprintAccess(bp, required_properties=['infrastructure_show'])
@@ -72,16 +80,20 @@ def format_reserved_addresses(subnet):
 
 @bp.route('/subnets/json')
 def subnets_json():
-    subnets_list = get_subnets_with_usage()
-    return jsonify(items=[{
-            'id': subnet.id,
-            'description': subnet.description,
-            'address': str(subnet.address),
-            'gateway': str(subnet.gateway),
-            'reserved': format_reserved_addresses(subnet),
-            'free_ips': f'{subnet.max_ips - subnet.used_ips}',
-            'free_ips_formatted': f'{subnet.max_ips - subnet.used_ips} (von {subnet.max_ips})',
-        } for subnet in subnets_list])
+    return TableResponse[SubnetRow](
+        items=[
+            SubnetRow(
+                id=subnet.id,
+                description=subnet.description,
+                address=str(subnet.address),
+                gateway=str(subnet.gateway),
+                reserved=format_reserved_addresses(subnet),
+                free_ips=f"{subnet.max_ips - subnet.used_ips}",
+                free_ips_formatted=f"{subnet.max_ips - subnet.used_ips} (von {subnet.max_ips})",
+            )
+            for subnet in get_subnets_with_usage()
+        ]
+    ).model_dump()
 
 
 @bp.route('/switches')
@@ -145,29 +157,44 @@ def switch_show_json(switch_id):
         abort(404)
     switch_port_list = switch.ports
     switch_port_list = sort_ports(switch_port_list)
-    T = PortTable
-    return jsonify(items=[{
-            "switchport_name": port.name,
-            "patchport_name": port.patch_port.name if port.patch_port else None,
-            "room": T.room.value(
-                href=url_for("facilities.room_show", room_id=port.patch_port.room.id),
-                title=port.patch_port.room.short_name
-            ) if port.patch_port else None,
-            "edit_link": T.edit_link.value(
-                href=url_for(".switch_port_edit",
-                             switch_id=switch.host.id, switch_port_id=port.id),
-                title="Bearbeiten",
-                icon='fa-edit',
-                btn_class='btn-link'
-            ),
-            "delete_link": T.delete_link.value(
-                href=url_for(".switch_port_delete",
-                             switch_id=switch.host.id, switch_port_id=port.id),
-                title="Löschen",
-                icon='fa-trash',
-                btn_class='btn-link'
-            ),
-        } for port in switch_port_list])
+
+    return TableResponse[PortRow](
+        items=[
+            PortRow(
+                switchport_name=port.name,
+                patchport_name=port.patch_port.name if port.patch_port else None,
+                room=LinkColResponse(
+                    href=url_for(
+                        "facilities.room_show", room_id=port.patch_port.room.id
+                    ),
+                    title=port.patch_port.room.short_name,
+                )
+                if port.patch_port
+                else None,
+                edit_link=BtnColResponse(
+                    href=url_for(
+                        ".switch_port_edit",
+                        switch_id=switch.host.id,
+                        switch_port_id=port.id,
+                    ),
+                    title="Bearbeiten",
+                    icon="fa-edit",
+                    btn_class="btn-link",
+                ),
+                delete_link=BtnColResponse(
+                    href=url_for(
+                        ".switch_port_delete",
+                        switch_id=switch.host.id,
+                        switch_port_id=port.id,
+                    ),
+                    title="Löschen",
+                    icon="fa-trash",
+                    btn_class="btn-link",
+                ),
+            )
+            for port in switch_port_list
+        ]
+    ).model_dump()
 
 
 @bp.route('/switch/create', methods=['GET', 'POST'])
@@ -419,8 +446,6 @@ def vlans():
 
 @bp.route('/vlans/json')
 def vlans_json():
-    return jsonify(items=[{
-            'id': vlan.id,
-            'name': vlan.name,
-            'vid': vlan.vid,
-        } for vlan in VLAN.q.all()])
+    return TableResponse[VlanRow](
+        items=[VlanRow.model_validate(vlan) for vlan in VLAN.q.all()]
+    ).model_dump()

--- a/web/blueprints/infrastructure/tables.py
+++ b/web/blueprints/infrastructure/tables.py
@@ -30,6 +30,19 @@ class SubnetTable(BootstrapTable):
     })
 
 
+class SubnetRow(BaseModel):
+    id: int
+    description: str | None
+    address: str
+    gateway: str
+    reserved: list[str]
+    free_ips: str  # the sort name
+    free_ips_formatted: str
+
+    class Config:
+        from_attributes = True
+
+
 class SwitchTable(BootstrapTable):
     id = Column("#")
     name = LinkColumn("Name")
@@ -59,6 +72,15 @@ class VlanTable(BootstrapTable):
     vid = Column("VID")
 
 
+class VlanRow(BaseModel):
+    id: int
+    name: str
+    vid: int
+
+    class Config:
+        from_attributes = True
+
+
 class PortTable(BootstrapTable):
     class Meta:
         table_args = {
@@ -81,3 +103,11 @@ class PortTable(BootstrapTable):
             return
         href = url_for(".switch_port_create", switch_id=self.switch_id)
         return button_toolbar("Switch-Port", href)
+
+
+class PortRow(BaseModel):
+    switchport_name: str
+    patchport_name: str | None
+    room: LinkColResponse | None
+    edit_link: BtnColResponse
+    delete_link: BtnColResponse

--- a/web/blueprints/infrastructure/tables.py
+++ b/web/blueprints/infrastructure/tables.py
@@ -1,8 +1,17 @@
 from flask import url_for
 from flask_login import current_user
+from pydantic import BaseModel
 
-from web.table.table import BootstrapTable, Column, LinkColumn, \
-    BtnColumn, button_toolbar
+
+from web.table.table import (
+    BootstrapTable,
+    Column,
+    LinkColumn,
+    BtnColumn,
+    button_toolbar,
+    LinkColResponse,
+    BtnColResponse,
+)
 
 
 def no_inf_change():
@@ -34,6 +43,14 @@ class SwitchTable(BootstrapTable):
             return
 
         return button_toolbar("Switch", url_for(".switch_create"))
+
+
+class SwitchRow(BaseModel):
+    id: int
+    name: LinkColResponse
+    ip: str
+    edit_link: BtnColResponse
+    delete_link: BtnColResponse
 
 
 class VlanTable(BootstrapTable):

--- a/web/blueprints/infrastructure/tables.py
+++ b/web/blueprints/infrastructure/tables.py
@@ -1,7 +1,6 @@
 from flask import url_for
 from flask_login import current_user
-from pydantic import BaseModel
-
+from pydantic import BaseModel, ConfigDict
 
 from web.table.table import (
     BootstrapTable,
@@ -31,6 +30,7 @@ class SubnetTable(BootstrapTable):
 
 
 class SubnetRow(BaseModel):
+    model_config = ConfigDict(from_attributes=True)
     id: int
     description: str | None
     address: str
@@ -38,9 +38,6 @@ class SubnetRow(BaseModel):
     reserved: list[str]
     free_ips: str  # the sort name
     free_ips_formatted: str
-
-    class Config:
-        from_attributes = True
 
 
 class SwitchTable(BootstrapTable):
@@ -73,12 +70,10 @@ class VlanTable(BootstrapTable):
 
 
 class VlanRow(BaseModel):
+    model_config = ConfigDict(from_attributes=True)
     id: int
     name: str
     vid: int
-
-    class Config:
-        from_attributes = True
 
 
 class PortTable(BootstrapTable):

--- a/web/blueprints/properties/__init__.py
+++ b/web/blueprints/properties/__init__.py
@@ -11,8 +11,7 @@
 """
 from itertools import chain
 
-from flask import Blueprint, flash, jsonify, redirect, render_template, url_for, \
-    abort
+from flask import Blueprint, flash, redirect, render_template, url_for, abort
 from flask_login import current_user
 from flask_wtf import FlaskForm
 
@@ -175,11 +174,3 @@ def property_group_delete(group_id):
                            page_title=f"Eigenschaftsgruppe '{group.name}' löschen",
                            form_args=form_args,
                            form=form)
-
-
-@bp.route('/json/propertygroups')
-def json_propertygroups():
-    groups = [(entry.id, entry.name) for entry in PropertyGroup.q.all()]
-
-    return jsonify(dict(items=groups))
-

--- a/web/blueprints/task/__init__.py
+++ b/web/blueprints/task/__init__.py
@@ -20,7 +20,7 @@ from web.blueprints.task.tables import TaskTable, TaskRow
 from web.table.table import (
     BtnColResponse,
     TableResponse,
-    datetime_format_pydantic,
+    datetime_format,
     LinkColResponse,
 )
 from web.template_filters import datetime_filter
@@ -54,7 +54,7 @@ def task_row(task: UserTask) -> TaskRow:
         status=task.status.name,
         parameters=format_parameters(asdict(task.parameters)),
         errors=task.errors if task.errors is not None else list(),
-        due=datetime_format_pydantic(task.due, default="", formatter=datetime_filter),
+        due=datetime_format(task.due, default="", formatter=datetime_filter),
         created=f"{task.created:%Y-%m-%d %H:%M:%S}",
         creator=LinkColResponse(
             href=url_for('user.user_show', user_id=task.creator.id),

--- a/web/blueprints/task/__init__.py
+++ b/web/blueprints/task/__init__.py
@@ -100,7 +100,7 @@ def json_tasks_for_user(user_id):
     user = get_user_or_404(user_id)
     return TableResponse[TaskRow](
         items=[task_row(t.cast(UserTask, task)) for task in user.tasks]
-    )
+    ).model_dump()
 
 
 @bp.route("/user/json")
@@ -119,7 +119,7 @@ def json_user_tasks():
 
     return TableResponse[TaskRow](
         items=[task_row(t.cast(UserTask, task)) for task in tasks]
-    )
+    ).model_dump()
 
 
 def get_task_or_404(task_id) -> Task | NoReturn:

--- a/web/blueprints/task/__init__.py
+++ b/web/blueprints/task/__init__.py
@@ -1,8 +1,8 @@
+import typing as t
 from dataclasses import asdict
 from typing import NoReturn
 
-from flask import Blueprint, jsonify, url_for, abort, flash, redirect, request, \
-    render_template
+from flask import Blueprint, url_for, abort, flash, redirect, request, render_template
 from flask_login import current_user
 
 from pycroft.exc import PycroftException
@@ -10,14 +10,19 @@ from pycroft.lib.task import cancel_task, task_type_to_impl, \
     manually_execute_task, reschedule_task
 from pycroft.model import session
 from pycroft.model.facilities import Building
-from pycroft.model.task import Task, TaskStatus
+from pycroft.model.task import Task, TaskStatus, UserTask
 from web.blueprints import redirect_or_404
 from web.blueprints.access import BlueprintAccess
 from web.blueprints.helpers.user import get_user_or_404
 from web.blueprints.navigation import BlueprintNavigation
 from web.blueprints.task.forms import RescheduleTaskForm
-from web.blueprints.task.tables import TaskTable
-from web.table.table import datetime_format
+from web.blueprints.task.tables import TaskTable, TaskRow
+from web.table.table import (
+    BtnColResponse,
+    TableResponse,
+    datetime_format_pydantic,
+    LinkColResponse,
+)
 from web.template_filters import datetime_filter
 
 bp = Blueprint('task', __name__)
@@ -36,28 +41,27 @@ def format_parameters(parameters):
     return parameters
 
 
-def task_row(task: Task):
+def task_row(task: UserTask) -> TaskRow:
     task_impl = task_type_to_impl.get(task.type)
-    T = TaskTable
-    return {
-        "id": task.id,
-        "user": T.user.value(
+    return TaskRow(
+        id=task.id,
+        user=LinkColResponse(
             href=url_for('user.user_show', user_id=task.user.id),
             title=task.user.name
         ),
-        "name": task_impl.name,
-        "type": task.type.name,
-        "status": task.status.name,
-        "parameters": format_parameters(asdict(task.parameters)),
-        "errors": task.errors if task.errors is not None else list(),
-        "due": datetime_format(task.due, default='', formatter=datetime_filter),
-        "created": f"{task.created:%Y-%m-%d %H:%M:%S}",
-        "creator": T.creator.value(
+        name=task_impl.name,
+        type=task.type.name,  # actually redundant, because we assume UserTask
+        status=task.status.name,
+        parameters=format_parameters(asdict(task.parameters)),
+        errors=task.errors if task.errors is not None else list(),
+        due=datetime_format_pydantic(task.due, default="", formatter=datetime_filter),
+        created=f"{task.created:%Y-%m-%d %H:%M:%S}",
+        creator=LinkColResponse(
             href=url_for('user.user_show', user_id=task.creator.id),
             title=task.creator.name
         ),
-        'actions': [
-            T.actions.single_value(
+        actions=[
+            BtnColResponse(
                 href=url_for(
                     '.cancel_user_task',
                     task_id=task.id,
@@ -67,7 +71,7 @@ def task_row(task: Task):
                 icon='fa-times',
                 btn_class='btn-link'
             ),
-            T.actions.single_value(
+            BtnColResponse(
                 href=url_for(
                     '.reschedule_user_task',
                     task_id=task.id,
@@ -77,7 +81,7 @@ def task_row(task: Task):
                 icon='fa-calendar-alt',
                 btn_class='btn-link'
             ),
-            T.actions.single_value(
+            BtnColResponse(
                 href=url_for(
                     '.manually_execute_user_task',
                     task_id=task.id,
@@ -88,14 +92,15 @@ def task_row(task: Task):
                 btn_class='btn-link'
             )
         ] if task.status == TaskStatus.OPEN else None,
-    }
+    )
 
 
 @bp.route("/user/<int:user_id>/json")
 def json_tasks_for_user(user_id):
     user = get_user_or_404(user_id)
-
-    return jsonify(items=[task_row(task) for task in user.tasks])
+    return TableResponse[TaskRow](
+        items=[task_row(t.cast(UserTask, task)) for task in user.tasks]
+    )
 
 
 @bp.route("/user/json")
@@ -112,7 +117,9 @@ def json_user_tasks():
     else:
         tasks = tasks.all()
 
-    return jsonify(items=[task_row(task) for task in tasks])
+    return TableResponse[TaskRow](
+        items=[task_row(t.cast(UserTask, task)) for task in tasks]
+    )
 
 
 def get_task_or_404(task_id) -> Task | NoReturn:

--- a/web/blueprints/task/tables.py
+++ b/web/blueprints/task/tables.py
@@ -1,5 +1,16 @@
-from web.table.table import BootstrapTable, Column, DateColumn, \
-    MultiBtnColumn, LinkColumn
+import typing as t
+from pydantic import BaseModel
+
+from web.table.table import (
+    BootstrapTable,
+    Column,
+    DateColumn,
+    MultiBtnColumn,
+    LinkColumn,
+    LinkColResponse,
+    DateColResponse,
+    BtnColResponse,
+)
 from web.blueprints.helpers.user import no_membership_change
 
 
@@ -34,3 +45,17 @@ class TaskTable(BootstrapTable):
         kw['table_args'] = table_args
 
         super().__init__(*a, **kw)
+
+
+class TaskRow(BaseModel):
+    id: int  # seems unused, not sure
+    user: LinkColResponse
+    name: str
+    type: str
+    due: DateColResponse
+    creator: LinkColResponse
+    status: str  # used by taskRowFormatter
+    actions: list[BtnColResponse]
+    created: str
+    parameters: dict[str, t.Any]
+    errors: list[str]  # used by taskDetailFormatter

--- a/web/blueprints/user/__init__.py
+++ b/web/blueprints/user/__init__.py
@@ -9,19 +9,16 @@
 
     :copyright: (c) 2012 by AG DSN.
 """
-import operator
 import re
 import typing as t
 from datetime import timedelta
 from functools import partial
-from itertools import chain
 from typing import TypeVar, Callable, cast
 
 from flask import (
     Blueprint,
     abort,
     flash,
-    jsonify,
     redirect,
     render_template,
     request,

--- a/web/blueprints/user/__init__.py
+++ b/web/blueprints/user/__init__.py
@@ -1095,7 +1095,7 @@ def room_history_json(user_id):
             )
             for history_entry in cast(list[RoomHistoryEntry], user.room_history_entries)
         ]
-    )
+    ).model_dump()
 
 
 @bp.route('<int:user_id>/json/tenancies')
@@ -1120,7 +1120,7 @@ def tenancies_json(user_id):
             )
             for tenancy in user.tenancies
         ]
-    )
+    ).model_dump()
 
 
 @bp.route('member-requests')

--- a/web/blueprints/user/__init__.py
+++ b/web/blueprints/user/__init__.py
@@ -570,38 +570,14 @@ def json_trafficdata(user_id, days=7):
 
     :param user_id:
     :param days: optional amount of days to be included
-    :return: JSON with traffic and credit data formatted according to the following schema
-    {
-        "type": "object",
-        "properties": {
-            "items": {
-                "type": "object",
-                "properties": {
-                    "traffic": {
-                        "type": "array",
-                        "items": {
-                            "type": "object",
-                            "properties": {
-                                "egress": { "type": "integer" },
-                                "ingress": { "type": "integer" },
-                                "timestamp": { "type": "string" }
-                                }
-                            }
-                        }
-                    }
-                }
-            }
-        }
-    }
+    :return:
     """
     interval = timedelta(days=days)
-    result = traffic_history(user_id, session.utcnow() - interval + timedelta(days=1), session.utcnow())
-
-    return jsonify(
-        items={
-            'traffic': [e.__dict__ for e in result]
-        }
-    )
+    utcnow = session.utcnow()
+    return [
+        e.__dict__
+        for e in traffic_history(user_id, utcnow - interval + timedelta(days=1), utcnow)
+    ]
 
 
 @bp.route('/create', methods=['GET', 'POST'])

--- a/web/blueprints/user/__init__.py
+++ b/web/blueprints/user/__init__.py
@@ -85,9 +85,9 @@ from web.blueprints.user.forms import (
 from web.table.table import (
     TableResponse,
     LinkColResponse,
-    datetime_format_pydantic,
+    datetime_format,
     BtnColResponse,
-    date_format_pydantic,
+    date_format,
 )
 from .log import formatted_user_hades_logs
 from .tables import (
@@ -462,12 +462,12 @@ def user_show_groups_json(user_id, group_filter="all"):
         items=[
             MembershipRow(
                 group_name=membership.group.name,
-                begins_at=datetime_format_pydantic(
+                begins_at=datetime_format(
                     membership.active_during.begin,
                     default="",
                     formatter=datetime_filter,
                 ),
-                ends_at=datetime_format_pydantic(
+                ends_at=datetime_format(
                     membership.active_during.end, default="", formatter=datetime_filter
                 ),
                 grants=granted,
@@ -1082,10 +1082,10 @@ def room_history_json(user_id):
     return TableResponse[RoomHistoryRow](
         items=[
             RoomHistoryRow(
-                begins_at=date_format_pydantic(
+                begins_at=date_format(
                     history_entry.active_during.begin, formatter=date_filter
                 ),
-                ends_at=date_format_pydantic(
+                ends_at=date_format(
                     history_entry.active_during.end, formatter=date_filter
                 ),
                 room=T.room.value(
@@ -1104,10 +1104,8 @@ def tenancies_json(user_id):
     return TableResponse[TenancyRow](
         items=[
             TenancyRow(
-                begins_at=date_format_pydantic(
-                    tenancy.mietbeginn, formatter=date_filter
-                ),
-                ends_at=date_format_pydantic(tenancy.mietende, formatter=date_filter),
+                begins_at=date_format(tenancy.mietbeginn, formatter=date_filter),
+                ends_at=date_format(tenancy.mietende, formatter=date_filter),
                 room=LinkColResponse(
                     href=url_for("facilities.room_show", room_id=tenancy.room.id)
                     if tenancy.room
@@ -1321,9 +1319,7 @@ def member_requests_json():
                 email=TextWithBooleanColResponse(
                     text=prm.email, bool=prm.email_confirmed
                 ),
-                move_in_date=date_format_pydantic(
-                    prm.move_in_date, formatter=date_filter
-                ),
+                move_in_date=date_format(prm.move_in_date, formatter=date_filter),
                 action_required=prm.room is not None
                 and prm.email_confirmed
                 and prm.is_adult,
@@ -1402,7 +1398,7 @@ def archivable_users_json():
                     for p in info.User.current_properties_maybe_denied
                 ),
                 num_hosts=len(info.User.hosts),
-                end_of_membership=date_format_pydantic(info.mem_end.date()),
+                end_of_membership=date_format(info.mem_end.date()),
             )
             for info in get_archivable_members(session.session)
         ]

--- a/web/blueprints/user/tables.py
+++ b/web/blueprints/user/tables.py
@@ -1,39 +1,17 @@
 import typing
 
 from flask import url_for
-
-from web.table.table import BootstrapTable, Column, \
-    LinkColumn, button_toolbar, MultiBtnColumn, DateColumn, RelativeDateColumn, \
-    TextWithBooleanColumn, UserColumn
+from web.blueprints.helpers.log_tables import RefreshableTableMixin
+from web.table.table import (
+    BootstrapTable,
+    Column,
+    LinkColumn,
+    button_toolbar,
+    MultiBtnColumn,
+    DateColumn,
+    TextWithBooleanColumn,
+)
 from web.blueprints.helpers.user import no_membership_change
-
-
-class RefreshableTableMixin:
-    """A mixin class showing the refresh button by default.
-
-    In :py:meth:`__init__`s ``table_args`` argument, a default of
-    ``{'data-show-refresh': "true"}`` is established.
-    """
-    def __init__(self, *a, **kw):
-        table_args = kw.pop('table_args', {})
-        table_args.setdefault('data-show-refresh', "true")
-        kw['table_args'] = table_args
-        super().__init__(*a, **kw)
-
-
-class LogTableExtended(RefreshableTableMixin, BootstrapTable):
-    """A table for displaying logs, with a ``type`` column"""
-    created_at = RelativeDateColumn("Erstellt um", width=2)
-    type_ = Column("Logtyp", name='type', sortable=False)
-    user = UserColumn("Nutzer")
-    message = Column("Nachricht", formatter='table.withMagicLinksFormatter')
-
-
-class LogTableSpecific(RefreshableTableMixin, BootstrapTable):
-    """A table for displaying logs"""
-    created_at = RelativeDateColumn("Erstellt um", width=2)
-    user = UserColumn("Nutzer")
-    message = Column("Nachricht", formatter='table.withMagicLinksFormatter')
 
 
 class MembershipTable(BootstrapTable):

--- a/web/blueprints/user/tables.py
+++ b/web/blueprints/user/tables.py
@@ -180,3 +180,11 @@ class ArchivableMembersTable(RefreshableTableMixin, BootstrapTable):
         ) -> dict:
             ...
 
+
+class ArchivableMemberRow(BaseModel):
+    id: int
+    user: LinkColResponse
+    room_shortname: LinkColResponse
+    num_hosts: int
+    current_properties: str
+    end_of_membership: DateColResponse

--- a/web/blueprints/user/tables.py
+++ b/web/blueprints/user/tables.py
@@ -104,6 +104,12 @@ class RoomHistoryTable(BootstrapTable):
     ends_at = DateColumn("Bis")
 
 
+class RoomHistoryRow(BaseModel):
+    room: LinkColResponse
+    begins_at: DateColResponse
+    ends_at: DateColResponse
+
+
 class TenancyTable(BootstrapTable):
     room = LinkColumn("Zimmer")
     begins_at = DateColumn("Von")
@@ -130,6 +136,24 @@ class PreMemberTable(BootstrapTable):
         table_args = {
             'data-row-style': 'table.membershipRequestRowFormatter',
         }
+
+
+class TextWithBooleanColResponse(BaseModel):
+    text: str
+    bool: bool
+    icon_true: str | None
+    icon_false: str | None
+
+
+class PreMemberRow(BaseModel):
+    prm_id: int | str
+    name: TextWithBooleanColResponse
+    login: str
+    email: TextWithBooleanColResponse
+    # email_confirmed?
+    move_in_date: DateColResponse
+    actions: list[BtnColResponse]
+    action_required: bool  # used by membershipRequestRowFormatter
 
 
 class ArchivableMembersTable(RefreshableTableMixin, BootstrapTable):

--- a/web/blueprints/user/tables.py
+++ b/web/blueprints/user/tables.py
@@ -13,6 +13,8 @@ from web.table.table import (
     DateColumn,
     TextWithBooleanColumn,
     LinkColResponse,
+    DateColResponse,
+    BtnColResponse,
 )
 from web.blueprints.helpers.user import no_membership_change
 
@@ -48,6 +50,18 @@ class MembershipTable(BootstrapTable):
             'data-row-style': 'table.membershipRowFormatter',
             'class': 'membership-table'
         }
+
+
+class MembershipRow(BaseModel):
+    group_name: str
+    begins_at: DateColResponse
+    ends_at: DateColResponse
+    actions: list[BtnColResponse]
+    # used by membershipRowAttributes
+    grants: list[str]
+    denies: list[str]
+    # used by membershipRowFormatter
+    active: bool
 
 
 class SearchTable(BootstrapTable):

--- a/web/blueprints/user/tables.py
+++ b/web/blueprints/user/tables.py
@@ -1,6 +1,8 @@
 import typing
 
 from flask import url_for
+from pydantic import BaseModel
+
 from web.blueprints.helpers.log_tables import RefreshableTableMixin
 from web.table.table import (
     BootstrapTable,
@@ -10,6 +12,7 @@ from web.table.table import (
     MultiBtnColumn,
     DateColumn,
     TextWithBooleanColumn,
+    LinkColResponse,
 )
 from web.blueprints.helpers.user import no_membership_change
 
@@ -54,10 +57,31 @@ class SearchTable(BootstrapTable):
     login = Column("Login")
 
 
+class UserSearchRow(BaseModel):
+    """note: contains more columns than just the response for the table.
+
+    specific search and quick search are actually different concerns,
+    but noone has separated this yet.
+    """
+
+    id: int
+    name: str
+    url: LinkColResponse
+    login: str
+    room_id: int | None
+
+
 class TrafficTopTable(BootstrapTable):
     """A table for displaying the users with the highest traffic usage"""
     url = LinkColumn("Name")
     traffic_for_days = Column("Traffic", formatter='table.byteFormatterBinary')
+
+
+class TrafficTopRow(BaseModel):
+    id: int
+    name: str
+    traffic_for_days: int
+    url: LinkColResponse
 
 
 class RoomHistoryTable(BootstrapTable):

--- a/web/blueprints/user/tables.py
+++ b/web/blueprints/user/tables.py
@@ -111,6 +111,13 @@ class TenancyTable(BootstrapTable):
     status = Column("Status")
 
 
+class TenancyRow(BaseModel):
+    room: LinkColResponse
+    begins_at: DateColResponse
+    ends_at: DateColResponse
+    status: str
+
+
 class PreMemberTable(BootstrapTable):
     prm_id = Column("ID")
     name = TextWithBooleanColumn("Name")

--- a/web/resources/js/traffic-graph.js
+++ b/web/resources/js/traffic-graph.js
@@ -74,7 +74,7 @@ $(() => {
             if (error) throw error;
 
             // Normalize data
-            const traffic = resp.items.traffic;
+            const traffic = resp;
             traffic.forEach(d => {
                 d.timestamp = d3.time.format.iso.parse(d.timestamp);
             });

--- a/web/table/table.py
+++ b/web/table/table.py
@@ -163,7 +163,7 @@ class BtnColResponse(BaseModel):
     title: str
     tooltip: str | None = None
     new_tab: bool | None = None
-    icon: IconClass | Iterable[IconClass] | None = None
+    icon: IconClass | list[IconClass] | None = None
 
 
 @custom_formatter_column('table.btnFormatter')

--- a/web/table/table.py
+++ b/web/table/table.py
@@ -480,7 +480,7 @@ class SplittedTable(BootstrapTable):
     splits: Iterable[tuple[str, str]]
 
     def _iter_typed_splits(self):
-        for t in self.splits:  # noqa[F402]
+        for t in self.splits:  # noqa: F402
             yield TableSplit(*t)
 
     @property

--- a/web/table/table.py
+++ b/web/table/table.py
@@ -5,12 +5,11 @@ from collections import OrderedDict
 from copy import copy
 from dataclasses import dataclass
 from datetime import date, datetime, time, timezone
-from functools import partial
 from operator import methodcaller
 from typing import Iterable, Any, Callable
 from urllib.parse import urlparse, parse_qsl, urlencode, urlunparse
 
-from pydantic import BaseModel, HttpUrl, AnyUrl, FilePath
+from pydantic import BaseModel
 from annotated_types import Predicate
 
 from .lazy_join import lazy_join, LazilyJoined
@@ -159,7 +158,7 @@ IconClass = t.Annotated[str, Predicate(methodcaller("startswith", "fa-"))]
 
 
 class BtnColResponse(BaseModel):
-    btn_class: BtnClass
+    btn_class: BtnClass | None = None
     href: str
     title: str
     tooltip: str | None = None
@@ -458,7 +457,7 @@ class SplittedTable(BootstrapTable):
     splits: Iterable[tuple[str, str]]
 
     def _iter_typed_splits(self):
-        for t in self.splits:
+        for t in self.splits:  # noqa[F402]
             yield TableSplit(*t)
 
     @property

--- a/web/table/table.py
+++ b/web/table/table.py
@@ -520,7 +520,7 @@ def iso_format(dt: datetime | date | None = None):
     return dt.isoformat(sep=' ')
 
 
-def date_format_pydantic(
+def date_format(
     dt: datetime | date | None,
     default: str | None = None,
     formatter: Callable = iso_format,
@@ -538,7 +538,7 @@ def date_format_pydantic(
     )
 
 
-def datetime_format_pydantic(
+def datetime_format(
     dt: datetime | None,
     default: str | None = None,
     formatter: Callable = iso_format,

--- a/web/table/table.py
+++ b/web/table/table.py
@@ -537,13 +537,6 @@ def date_format_pydantic(
         ),
     )
 
-def date_format(dt: datetime | date | None,
-                default: str | None = None, formatter: Callable = iso_format) -> dict:
-    import warnings
-
-    warnings.warn("use date_format_pydantic instead", DeprecationWarning, stacklevel=2)
-    return date_format_pydantic(dt, default, formatter).model_dump()
-
 
 def datetime_format_pydantic(
     dt: datetime | None,
@@ -560,16 +553,6 @@ def datetime_format_pydantic(
         timestamp=int(dt.timestamp()),
     )
 
-
-def datetime_format(dt: datetime | None,
-                    default: str | None = None,
-                    formatter: Callable = iso_format) -> dict:
-    import warnings
-
-    warnings.warn(
-        "use datetime_format_pydantic instead", DeprecationWarning, stacklevel=2
-    )
-    return datetime_format_pydantic(dt, default, formatter).model_dump()
 
 def enforce_url_params(url, params):
     """Safely enforce query values in an url


### PR DESCRIPTION
The goal of this PR is to replace the dicts returned in the table JSON endpoints by pydantic models.
After having done this, frontend tests can utilize these models to validate responses and do easier introspection.

possible next issue:
- [ ] pydantic models for `/api` endpoints