### PR TITLE
Always enable splitting during bundling

### DIFF
--- a/bundle.ts
+++ b/bundle.ts
@@ -44,7 +44,7 @@ const options: esbuild.BuildOptions = {
   logLevel: "info",
 
   bundle: true,
-  splitting: args.prod,
+  splitting: true,
   minify: args.prod,
   treeShaking: args.prod,
   sourcemap: true,
@@ -73,7 +73,7 @@ const options: esbuild.BuildOptions = {
   inject: [path.join(src, "inject-jquery.js")],
   plugins: [{name: "manifest", setup(build){
     build.onEnd(result => generateManifest(result, src, dst))}
-  }].concat(args.prod ? [ 
+  }].concat(args.prod ? [
     clean({
       patterns: [dst + "/**"],
     })

--- a/web/resources/js/tab-anchor.ts
+++ b/web/resources/js/tab-anchor.ts
@@ -26,7 +26,7 @@ function updateLocationHash(this: HTMLElement, _: MouseEvent){
     }
 }
 
-document.addEventListener('DOMContentLoaded', () => {
+window.addEventListener('load', () => {
     navigateToAnchorTab();
 
     for (const el of document.querySelectorAll<HTMLElement>('.nav-tabs [role="tab"]')) {


### PR DESCRIPTION
Apparently issues appear when bundling Bootstrap in multiple files.