### PR TITLE
Adjust unconfirmed transactions table

### DIFF
--- a/web/blueprints/finance/__init__.py
+++ b/web/blueprints/finance/__init__.py
@@ -1181,13 +1181,13 @@ def _format_transaction_row(
     bank_acc_act: BankAccountActivity | None,
 ) -> UnconfirmedTransactionsRow:
     return UnconfirmedTransactionsRow(
-        id=transaction.id,
         description=LinkColResponse(
             href=url_for(".transactions_show", transaction_id=transaction.id),
             title=transaction.description,
             new_tab=True,
             glyphicon="fa-external-link-alt",
         ),
+        other_name=bank_acc_act.other_name if bank_acc_act else None,
         user=(
             LinkColResponse(
                 href=url_for("user.user_show", user_id=user_account.user.id),
@@ -1205,17 +1205,6 @@ def _format_transaction_row(
             if user_account and user_account.user and user_account.user.room
             else None
         ),
-        author=(
-            LinkColResponse(
-                href=url_for("user.user_show", user_id=transaction.author.id),
-                title=transaction.author.name,
-                new_tab=True,
-            )
-            if transaction.author
-            else None
-        ),
-        date=date_format(transaction.posted_at, formatter=date_filter),
-        amount=money_filter(transaction.amount),
         actions=list(_iter_transaction_buttons(bank_acc_act, transaction)),
     )
 

--- a/web/blueprints/finance/tables.py
+++ b/web/blueprints/finance/tables.py
@@ -306,24 +306,18 @@ class TransactionSplitResponse(TableResponse[TransactionSplitRow]):
 class UnconfirmedTransactionsTable(BootstrapTable):
     """A table for displaying unconfirmed transactions """
     selection = Column("Checkbox", col_args={"data-checkbox": "true"})
-    id = Column("id")
     description = LinkColumn("Beschreibung")
+    other_name = Column("Bankkontoinhaber")
     user = LinkColumn("Nutzer")
     room = Column("Wohnort")
-    date = DateColumn("Datum")
-    amount = Column("Wert")
-    author = LinkColumn("Ersteller")
     actions = MultiBtnColumn("Aktionen")
 
 
 class UnconfirmedTransactionsRow(BaseModel):
-    id: str | int
     description: LinkColResponse
+    other_name: str | None = None
     user: LinkColResponse | None = None
     room: str | None = None
-    date: DateColResponse
-    amount: str
-    author: LinkColResponse | None = None
     actions: list[BtnColResponse]
 
 


### PR DESCRIPTION
id, author, date and amount are usually not of interest in the first
place.

They're easily accessible still though:
* id: in url of description, e.g. visible via hover
* author: in transaction detail view reachable via click on transaction description
* date: in transaction detail view reachable via click on transaction description
* amount: in bank account activity view reachable via click on bank account activity button

The other bank account owner has been added to the table as that's what's usually checked.
