### PR TITLE
Typo in table js  removed

### DIFF
--- a/web/resources/js/table.js
+++ b/web/resources/js/table.js
@@ -223,7 +223,7 @@ export function relativeDateFormatter(value, row, index) {
         </span>
     `;
 }
-dateFormatter.attributes = { sortName: 'timestamp' };
+relativeDateFormatter.attributes = { sortName: 'timestamp' };
 
 export function euroFormatter(value, row, index){
     const eur = parseFloat(value).toFixed(2).replace('.', ',');


### PR DESCRIPTION
# what was done
there was a typo in the which did not add the attriubte to relativeDateFormatter 
# fixes 
#764