### PR TITLE
Prevent form from being submitted multiple times by disable button

### DIFF
--- a/web/resources/js/form.js
+++ b/web/resources/js/form.js
@@ -136,3 +136,12 @@ export function pycroftIntervalPicker(IntervalField) {
     $('#' + IntervalField + 'PickerI').val(data[8]);
     $('#' + IntervalField + 'PickerS').val(data[10]);
 }
+
+/*
+* Prevents the multiple submission of a form
+*/
+for (const form of document.getElementsByTagName("form")) {
+    form.addEventListener("submit", (event) => {
+        event.submitter.disabled = true;
+    });
+}


### PR DESCRIPTION
By listen on form submission and disable the button, we prevent the ability of sending a request twice

![Blocked import button](https://github.com/user-attachments/assets/2905422b-48c2-46fd-83ee-edec976ad7ba)
