### PR TITLE
Unselect active members by default at handling of payments in default

### DIFF
--- a/pycroft/lib/finance/__init__.py
+++ b/pycroft/lib/finance/__init__.py
@@ -40,6 +40,7 @@ from .payment_in_default import (
     get_users_with_payment_in_default,
     take_actions_for_payment_in_default_users,
     get_pid_csv,
+    filter_active_members_from_users_with_payment_in_default,
 )
 from .retransfer import (
     attribute_activities_as_returned,

--- a/pycroft/lib/finance/__init__.py
+++ b/pycroft/lib/finance/__init__.py
@@ -40,7 +40,7 @@ from .payment_in_default import (
     get_users_with_payment_in_default,
     take_actions_for_payment_in_default_users,
     get_pid_csv,
-    filter_active_members_from_users_with_payment_in_default,
+    filter_active_members_from_users_with_pid,
 )
 from .retransfer import (
     attribute_activities_as_returned,

--- a/pycroft/lib/finance/payment_in_default.py
+++ b/pycroft/lib/finance/payment_in_default.py
@@ -128,6 +128,28 @@ def get_users_with_payment_in_default(session: Session) -> tuple[set[User], set[
     return users_pid_membership, users_membership_terminated
 
 
+def filter_active_members_from_users_with_payment_in_default(
+    users_with_pid: tuple[set[User], set[User]],
+) -> tuple[set[User], set[User]]:
+    """Determine which users should be blocked and whose membership should be terminated
+        excluding active members.
+
+    :returns: which users should be added to the ``payment_in_default`` group (``[0]``)
+        and which ones should get their membership terminated (``[1]``).
+    """
+    users_pid_membership_all, users_membership_terminated_all = users_with_pid
+    filtered_users_pid_membership_all = set(
+        filter(lambda user: not user.has_property("active_member"), users_pid_membership_all)
+    )
+    filtered_users_membership_terminated_all = set(
+        filter(
+            lambda user: not user.has_property("active_member"),
+            users_membership_terminated_all,
+        )
+    )
+    return filtered_users_pid_membership_all, filtered_users_membership_terminated_all
+
+
 @with_transaction
 def take_actions_for_payment_in_default_users(
     users_pid_membership: t.Iterable[User],

--- a/pycroft/lib/finance/payment_in_default.py
+++ b/pycroft/lib/finance/payment_in_default.py
@@ -128,7 +128,7 @@ def get_users_with_payment_in_default(session: Session) -> tuple[set[User], set[
     return users_pid_membership, users_membership_terminated
 
 
-def filter_active_members_from_users_with_payment_in_default(
+def filter_active_members_from_users_with_pid(
     users_with_pid: tuple[set[User], set[User]],
 ) -> tuple[set[User], set[User]]:
     """Determine which users should be blocked and whose membership should be terminated

--- a/tests/lib/test_finance.py
+++ b/tests/lib/test_finance.py
@@ -139,7 +139,6 @@ class TestMembershipFeePosting:
         reg_date = utcnow - timedelta(weeks=52)
         user = UserFactory(
             registered_at=reg_date,
-            birthdate=datetime.now(),
             with_membership=True,
             membership__active_during=starting_from(reg_date),
             membership__group=SubFactory(ActiveMemberPropertyGroupFactory),
@@ -345,7 +344,7 @@ class TestMembershipFeePosting:
             users_membership_terminated,
         ) = get_users_with_payment_in_default(session)
         (filtered_users_pid_membership, filtered_users_membership_terminated) = (
-            finance.filter_active_members_from_users_with_payment_in_default(
+            finance.filter_active_members_from_users_with_pid(
                 (users_pid_membership, users_membership_terminated)
             )
         )

--- a/tests/lib/test_finance.py
+++ b/tests/lib/test_finance.py
@@ -6,7 +6,7 @@ from datetime import date, timedelta, datetime, timezone
 from decimal import Decimal
 
 import pytest
-from factory import Iterator
+from factory import Iterator, SubFactory
 from sqlalchemy.orm import Session
 
 from pycroft import Config
@@ -29,7 +29,7 @@ from pycroft.model.finance import (
     MembershipFee,
 )
 from pycroft.model.user import Membership, User
-from tests.factories import MembershipFactory, ConfigFactory
+from tests.factories import MembershipFactory, ConfigFactory, ActiveMemberPropertyGroupFactory
 from tests.factories.finance import (
     MembershipFeeFactory,
     TransactionFactory,
@@ -133,6 +133,19 @@ class TestMembershipFeePosting:
             membership__group=config.member_group,
             without_room=True,
         )
+
+    @pytest.fixture
+    def user_from1y_active_member(self, session, utcnow):
+        reg_date = utcnow - timedelta(weeks=52)
+        user = UserFactory(
+            registered_at=reg_date,
+            birthdate=datetime.now(),
+            with_membership=True,
+            membership__active_during=starting_from(reg_date),
+            membership__group=SubFactory(ActiveMemberPropertyGroupFactory),
+        )
+        session.flush()
+        return user
 
     @pytest.fixture
     def user_move_in_grace(
@@ -331,8 +344,13 @@ class TestMembershipFeePosting:
             users_pid_membership,
             users_membership_terminated,
         ) = get_users_with_payment_in_default(session)
+        (filtered_users_pid_membership, filtered_users_membership_terminated) = (
+            finance.filter_active_members_from_users_with_payment_in_default(
+                (users_pid_membership, users_membership_terminated)
+            )
+        )
         take_actions_for_payment_in_default_users(
-            users_pid_membership, users_membership_terminated, processor
+            filtered_users_pid_membership, filtered_users_membership_terminated, processor
         )
 
         return users_pid_membership, users_membership_terminated
@@ -441,6 +459,29 @@ class TestMembershipFeePosting:
         session.refresh(user)
         assert user.has_property("member"), "User is not a member"
         assert not user.has_property("payment_in_default"), "User has payment_in_default property"
+
+    def test_payment_in_default_active_member(
+        self, user_from1y_active_member, session, processor, fees
+    ):
+        user = user_from1y_active_member
+
+        assert user.account.balance == 0.00, "Initial user account balance not zero"
+        assert user.account.in_default_days == 0
+        assert user.has_property("member"), "User is not a member"
+
+        # Test fee with payment_in_default group action
+        post_transactions_for_membership_fee(fees.pid_state, processor)
+        session.refresh(user.account)
+
+        assert user.account.balance == fees.pid_state.regular_fee, "User balance incorrect"
+
+        self.handle_payment_in_default_users(session, processor)
+
+        session.refresh(user)
+        assert user.has_property("member"), "User is not a member"
+        assert not user.has_property(
+            "payment_in_default"
+        ), "Active member has payment_in_default property"
 
 
 class TestSplitTypes:

--- a/web/blueprints/finance/__init__.py
+++ b/web/blueprints/finance/__init__.py
@@ -1690,9 +1690,10 @@ def handle_payments_in_default() -> ResponseReturnValue:
     form.terminated_member_memberships.query_factory = lambda: users_membership_terminated_all
 
     if not form.is_submitted():
-        form.new_pid_memberships.process_data(users_pid_membership_all)
+        form.new_pid_memberships.process_data(
+            set(filter(lambda user: not user.has_property("active_member"), users_pid_membership_all)))
         form.terminated_member_memberships.process_data(
-            users_membership_terminated_all)
+            set(filter(lambda user: not user.has_property("active_member"), users_membership_terminated_all)))
 
     if form.validate_on_submit():
         users_pid_membership = form.new_pid_memberships.data

--- a/web/blueprints/finance/__init__.py
+++ b/web/blueprints/finance/__init__.py
@@ -1690,21 +1690,13 @@ def handle_payments_in_default() -> ResponseReturnValue:
     form.terminated_member_memberships.query_factory = lambda: users_membership_terminated_all
 
     if not form.is_submitted():
-        form.new_pid_memberships.process_data(
-            set(
-                filter(
-                    lambda user: not user.has_property("active_member"), users_pid_membership_all
-                )
+        filtered_users_pid_membership_all, filtered_users_membership_terminated_all = (
+            finance.filter_active_members_from_users_with_payment_in_default(
+                (users_pid_membership_all, users_membership_terminated_all)
             )
         )
-        form.terminated_member_memberships.process_data(
-            set(
-                filter(
-                    lambda user: not user.has_property("active_member"),
-                    users_membership_terminated_all,
-                )
-            )
-        )
+        form.new_pid_memberships.process_data(filtered_users_pid_membership_all)
+        form.terminated_member_memberships.process_data(filtered_users_membership_terminated_all)
 
     if form.validate_on_submit():
         users_pid_membership = form.new_pid_memberships.data

--- a/web/blueprints/finance/__init__.py
+++ b/web/blueprints/finance/__init__.py
@@ -1691,7 +1691,7 @@ def handle_payments_in_default() -> ResponseReturnValue:
 
     if not form.is_submitted():
         filtered_users_pid_membership_all, filtered_users_membership_terminated_all = (
-            finance.filter_active_members_from_users_with_payment_in_default(
+            finance.filter_active_members_from_users_with_pid(
                 (users_pid_membership_all, users_membership_terminated_all)
             )
         )

--- a/web/blueprints/finance/__init__.py
+++ b/web/blueprints/finance/__init__.py
@@ -1691,9 +1691,20 @@ def handle_payments_in_default() -> ResponseReturnValue:
 
     if not form.is_submitted():
         form.new_pid_memberships.process_data(
-            set(filter(lambda user: not user.has_property("active_member"), users_pid_membership_all)))
+            set(
+                filter(
+                    lambda user: not user.has_property("active_member"), users_pid_membership_all
+                )
+            )
+        )
         form.terminated_member_memberships.process_data(
-            set(filter(lambda user: not user.has_property("active_member"), users_membership_terminated_all)))
+            set(
+                filter(
+                    lambda user: not user.has_property("active_member"),
+                    users_membership_terminated_all,
+                )
+            )
+        )
 
     if form.validate_on_submit():
         users_pid_membership = form.new_pid_memberships.data


### PR DESCRIPTION
While we handle payments in default, it's hard to separate between members and active members.

Waiting for https://github.com/agdsn/pycroft/pull/780 to be merged since property group "active_member" is missing