### PR TITLE
Add dormitory option to group mail feature

### DIFF
--- a/pycroft/lib/user/__init__.py
+++ b/pycroft/lib/user/__init__.py
@@ -63,7 +63,7 @@ from .mail import (
     format_user_mail,
     user_send_mails,
     user_send_mail,
-    get_active_users,
+    get_active_users_with_building,
     group_send_mail,
     send_member_request_merged_email,
     send_confirmation_email,

--- a/pycroft/lib/user/mail.py
+++ b/pycroft/lib/user/mail.py
@@ -18,8 +18,8 @@ from pycroft.model.user import (
     User,
     PreMember,
     BaseUser,
-    PropertyGroup,
     Membership,
+    PropertyGroup,
 )
 from pycroft.model.facilities import Building, Room
 from pycroft.task import send_mails_async
@@ -126,24 +126,35 @@ def user_send_mail(
     user_send_mails([user], template, soft_fail, use_internal, **kwargs)
 
 
-def get_active_users(
-    session: Session, group: PropertyGroup, building: Building | None = None
+def get_active_users_with_building(
+    session: Session, groups: t.List[PropertyGroup], buildings: t.List[Building]
 ) -> ScalarResult[User]:
-    statement = (
-        select(User).join(User.current_memberships).where(Membership.group == group).distinct()
-    )
 
+    statement = select(User)
+
+    if len(groups) > 0:
+        group_ids: t.List[int] = [g.id for g in groups]
+        statement = (
+            statement.join(User.current_memberships)
+            .where(Membership.group_id.in_(group_ids))
+            .distinct()
+        )
     # if building is not None, we add the filter to the query
-    if building is not None:
-        statement = statement.join(User.room).join(Room.building).where(Building.id == building.id)
+    if len(buildings) > 0:
+        building_ids: t.List[int] = [b.id for b in buildings]
+        statement = (
+            statement.join(User.room).join(Room.building).where(Building.id.in_(building_ids))
+        )
 
     return session.scalars(statement)
 
 
 def group_send_mail(
-    group: PropertyGroup, subject: str, body_plain: str, building: Building | None = None
+    groups: t.List[PropertyGroup], subject: str, body_plain: str, buildings: t.List[Building]
 ) -> None:
-    users = get_active_users(session=session.session, group=group, building=building)
+    users = get_active_users_with_building(
+        session=session.session, groups=groups, buildings=buildings
+    )
     user_send_mails(users, soft_fail=True, body_plain=body_plain, subject=subject)
 
 

--- a/tests/lib/user/test_active_members.py
+++ b/tests/lib/user/test_active_members.py
@@ -2,7 +2,7 @@ import pytest
 from datetime import datetime, timedelta
 
 from pycroft.helpers.interval import closedopen
-from pycroft.lib.user import get_active_users
+from pycroft.lib.user import get_active_users_with_building
 from pycroft.model.user import PropertyGroup, User
 from tests import factories as f
 
@@ -49,4 +49,4 @@ def users_without_mem(module_session, yesterday, g) -> tuple[User, User]:
 
 
 def test_get_active_members(session, g, users_with_mem):
-    assert set(get_active_users(session, g)) == set(users_with_mem)
+    assert set(get_active_users_with_building(session, [g], [])) == set(users_with_mem)

--- a/tests/lib/user/test_mail.py
+++ b/tests/lib/user/test_mail.py
@@ -1,0 +1,89 @@
+#  Copyright (c) 2025. The Pycroft Authors. See the AUTHORS file.
+#  This file is part of the Pycroft project and licensed under the terms of
+#  the Apache License, Version 2.0. See the LICENSE file for details
+import pytest
+
+from pycroft.lib.user import get_active_users
+from pycroft.model.facilities import Room, Building
+from itertools import combinations
+
+from pycroft.model.user import User
+from ...factories import UserFactory, RoomFactory, BuildingFactory, AddressFactory
+
+
+@pytest.fixture(scope="module")
+def user(module_session, config) -> User:
+    return UserFactory(
+        room=RoomFactory(building=BuildingFactory.create()),
+        address=AddressFactory(),
+        membership__group=config.violation_group,
+        with_membership=True,
+    )
+
+
+@pytest.fixture(scope="module")
+def user_no_room(module_session, config) -> User:
+    return UserFactory.create(
+        room=None,
+        address=AddressFactory(),
+        membership__group=config.member_group,
+        with_membership=True,
+    )
+
+
+@pytest.fixture(scope="module")
+def building_list(module_session) -> list[Building]:
+    out = []
+    for _ in range(20):
+        b = BuildingFactory.create()
+        out.append(b)
+    return out
+
+
+@pytest.fixture(scope="module")
+def build_map(module_session, config, building_list) -> dict:
+    out = {}
+    for building in building_list:
+        out[building] = []
+        for _ in range(5):
+            user = UserFactory.create(
+                room=RoomFactory(building=building),
+                membership__group=config.member_group,
+                with_membership=True,
+            )
+            out[building].append(user)
+    return out
+
+
+@pytest.fixture(scope="module")
+def room(module_session) -> Room:
+    return RoomFactory()
+
+
+class TestMailSelectWtihoutBulding:
+
+    def test_mail_just_goup(self, session, config, build_map, user_no_room):
+        session.flush()
+        length = sum(len(v) for v in build_map.values()) + 1
+        users = get_active_users(session, [config.member_group], [])
+
+        assert len(users.all()) == length
+
+    def test_building(self, session, config, build_map):
+        session.flush()
+        for building, userlist in build_map.items():
+            users = get_active_users(session, [config.member_group], [building])
+            assert len(users.all()) == len(userlist)
+
+    def test_multi_building(self, session, config, build_map):
+        session.flush()
+        for comb in combinations(build_map.keys(), 2):
+            users = get_active_users(session, [config.member_group], comb)
+            length = sum(len(build_map[building]) for building in comb)
+            assert len(users.all()) == length
+
+    def test_not_found_in_building(self, session, config, build_map, user, building_list):
+        users = get_active_users(session, [config.violation_group], [])
+        assert len(users.all()) == 1
+        users = get_active_users(session, [config.violation_group], building_list)
+        assert len(users.all()) == 0

--- a/tests/lib/user/test_mail.py
+++ b/tests/lib/user/test_mail.py
@@ -3,7 +3,7 @@
 #  the Apache License, Version 2.0. See the LICENSE file for details
 import pytest
 
-from pycroft.lib.user import get_active_users
+from pycroft.lib.user import get_active_users_with_building
 from pycroft.model.facilities import Room, Building
 from itertools import combinations
 
@@ -65,25 +65,25 @@ class TestMailSelectWtihoutBulding:
     def test_mail_just_goup(self, session, config, build_map, user_no_room):
         session.flush()
         length = sum(len(v) for v in build_map.values()) + 1
-        users = get_active_users(session, [config.member_group], [])
+        users = get_active_users_with_building(session, [config.member_group], [])
 
         assert len(users.all()) == length
 
     def test_building(self, session, config, build_map):
         session.flush()
         for building, userlist in build_map.items():
-            users = get_active_users(session, [config.member_group], [building])
+            users = get_active_users_with_building(session, [config.member_group], [building])
             assert len(users.all()) == len(userlist)
 
     def test_multi_building(self, session, config, build_map):
         session.flush()
         for comb in combinations(build_map.keys(), 2):
-            users = get_active_users(session, [config.member_group], comb)
+            users = get_active_users_with_building(session, [config.member_group], comb)
             length = sum(len(build_map[building]) for building in comb)
             assert len(users.all()) == length
 
     def test_not_found_in_building(self, session, config, build_map, user, building_list):
-        users = get_active_users(session, [config.violation_group], [])
+        users = get_active_users_with_building(session, [config.violation_group], [])
         assert len(users.all()) == 1
-        users = get_active_users(session, [config.violation_group], building_list)
+        users = get_active_users_with_building(session, [config.violation_group], building_list)
         assert len(users.all()) == 0

--- a/web/blueprints/user/__init__.py
+++ b/web/blueprints/user/__init__.py
@@ -1540,10 +1540,10 @@ def mail_group() -> ResponseReturnValue:
 
     if form.validate_on_submit():
         lib.user.group_send_mail(
-            group=form.group.data,
+            groups=form.groups.data,
             subject=form.subject.data,
             body_plain=form.body_plain.data,
-            building=form.building.data if getattr(form, "building", None) else None,
+            buildings=form.buildings.data if getattr(form, "building", None) else [],
         )
 
         flash("Rundmail versendet!", "success")

--- a/web/blueprints/user/__init__.py
+++ b/web/blueprints/user/__init__.py
@@ -1543,6 +1543,7 @@ def mail_group() -> ResponseReturnValue:
             group=form.group.data,
             subject=form.subject.data,
             body_plain=form.body_plain.data,
+            building=form.building.data if getattr(form, "building", None) else None,
         )
 
         flash("Rundmail versendet!", "success")

--- a/web/blueprints/user/forms.py
+++ b/web/blueprints/user/forms.py
@@ -333,14 +333,26 @@ class UserMoveOutForm(Form):
     end_membership = BooleanField("Mitgliedschaft/Extern beenden", [Optional()])
 
 
+def at_least_one_required(form: Form, field: Field) -> None:
+    if not field.data:
+        raise ValidationError("Mindestens eine Gruppe muss ausgewählt werden!")
+
+
 class GroupMailForm(Form):
-    group = QuerySelectField("Gruppe", [DataRequired()], get_label='name', query_factory=group_query)
-    building = QuerySelectField(
-        "Wohnheim",
+    groups = QuerySelectMultipleField(
+        "Gruppen",
+        get_label="name",
+        query_factory=group_query,
+        validators=[at_least_one_required],
+        default=[],
+    )
+    buildings = QuerySelectMultipleField(
+        "Wohnheime",
         get_label="short_name",
         query_factory=building_query,
         allow_blank=True,
         blank_text="<Wohnheim>",
+        default=[],
     )
     subject = TextField("Betreff", [DataRequired()])
     body_plain = TextAreaField("E-Mail (plaintext)", [DataRequired()],

--- a/web/blueprints/user/forms.py
+++ b/web/blueprints/user/forms.py
@@ -335,6 +335,13 @@ class UserMoveOutForm(Form):
 
 class GroupMailForm(Form):
     group = QuerySelectField("Gruppe", [DataRequired()], get_label='name', query_factory=group_query)
+    building = QuerySelectField(
+        "Wohnheim",
+        get_label="short_name",
+        query_factory=building_query,
+        allow_blank=True,
+        blank_text="<Wohnheim>",
+    )
     subject = TextField("Betreff", [DataRequired()])
     body_plain = TextAreaField("E-Mail (plaintext)", [DataRequired()],
                                description="Verfügbar: {name}, {login}, {id}, {email}, "


### PR DESCRIPTION
The title says it all. Dormitories should remain optional so it's still possible to send a mail to all members.

An idea for the future would be to migrate dormitories and groups into multiple-choice fields.