### PR TITLE
Add enpoints to generate bank transfer xml files

### DIFF
--- a/pycroft/lib/finance/__init__.py
+++ b/pycroft/lib/finance/__init__.py
@@ -46,6 +46,7 @@ from .retransfer import (
     attribute_activities_as_returned,
     generate_activities_return_sepaxml,
     get_activities_to_return,
+    generate_transfer_sepaxml,
 )
 from .transaction_crud import (
     simple_transaction,

--- a/pycroft/lib/finance/retransfer.py
+++ b/pycroft/lib/finance/retransfer.py
@@ -8,7 +8,7 @@ from sqlalchemy.orm import Session, joinedload
 
 from pycroft import config
 from pycroft.helpers.utc import ensure_tz
-from pycroft.model.finance import BankAccountActivity
+from pycroft.model.finance import BankAccountActivity, BankAccount
 from pycroft.model.user import User
 
 from .transaction_crud import simple_transaction
@@ -76,3 +76,31 @@ def attribute_activities_as_returned(
             split for split in transaction.splits if split.account_id == credit_account.id
         )
         session.add(activity)
+
+
+def generate_transfer_sepaxml(
+    bank_account: BankAccount, owner: str, iban: str, bic: str, reason: str, amount: int
+) -> bytes:
+    transfer_config: dict = {
+        "name": bank_account.owner,
+        "IBAN": bank_account.iban,
+        "BIC": bank_account.bic,
+        "batch": False,
+        "currency": "EUR",
+    }
+    sepa = SepaTransfer(transfer_config, clean=False)
+
+    formatted_iban = IBAN(iban)
+    formatted_bic = BIC(bic)
+
+    payment = {
+        "name": owner,
+        "IBAN": formatted_iban.compact,
+        "BIC": formatted_bic.compact,
+        "amount": int(amount * 100),
+        "execution_date": datetime.now().date(),
+        "description": reason[:140],
+    }
+    sepa.add_payment(payment)
+
+    return sepa.export()

--- a/tests/frontend/test_finance.py
+++ b/tests/frontend/test_finance.py
@@ -797,22 +797,38 @@ class TestTransferGeneration:
         return u
 
     def test_generate_retransfer(self, client: TestClient, user, bank_account):
-        client.assert_url_ok(url_for("finance.bank_account_retransfer", user_id=user.id))
+        client.assert_url_ok(url_for("finance.bank_account_transfer", user_id=user.id))
 
-        formdata = serialize_formdata(
+        form_data = serialize_formdata(
             {
                 "bank_account": bank_account.id,
-                "user_name": user.name,
+                "owner": user.name,
                 "iban": "DE61850503003120219540",
                 "bic": "OSDDDE81XXX",
-                "reason": "test",
                 "amount": 10,
+                "reference": "test",
             }
         )
         client.assert_url_ok(
-            url_for("finance.bank_account_retransfer", user_id=user.id),
+            url_for("finance.bank_account_transfer", user_id=user.id),
             method="POST",
-            data=formdata,
+            data=form_data,
+        )
+
+        invalid_form_data = serialize_formdata(
+            {
+                "bank_account": bank_account.id,
+                "owner": user.name,
+                "iban": "2D",
+                "bic": "E3",
+                "amount": -10,
+                "reference": "test",
+            }
+        )
+        client.assert_url_ok(
+            url_for("finance.bank_account_transfer", user_id=user.id),
+            method="POST",
+            data=invalid_form_data,
         )
 
     def test_generate_transfer(self, client: TestClient, bank_account):

--- a/tests/frontend/test_finance.py
+++ b/tests/frontend/test_finance.py
@@ -788,6 +788,7 @@ class TestConfirmSelected:
         resp = client.assert_url_ok(url_for("finance.transactions_unconfirmed_json"))
         assert len(resp.json["items"]) == 0
 
+
 class TestTransferGeneration:
     @pytest.fixture
     def user(self, session):

--- a/tests/frontend/test_finance.py
+++ b/tests/frontend/test_finance.py
@@ -801,7 +801,7 @@ class TestTransferGeneration:
 
         formdata = serialize_formdata(
             {
-                "bank_account": bank_account,
+                "bank_account": bank_account.id,
                 "user_name": user.name,
                 "iban": "DE61850503003120219540",
                 "bic": "OSDDDE81XXX",
@@ -820,7 +820,7 @@ class TestTransferGeneration:
 
         formdata = serialize_formdata(
             {
-                "bank_account": bank_account,
+                "bank_account": bank_account.id,
                 "owner": "Tester",
                 "iban": "DE61850503003120219540",
                 "bic": "OSDDDE81XXX",

--- a/tests/frontend/test_finance.py
+++ b/tests/frontend/test_finance.py
@@ -787,3 +787,50 @@ class TestConfirmSelected:
         )
         resp = client.assert_url_ok(url_for("finance.transactions_unconfirmed_json"))
         assert len(resp.json["items"]) == 0
+
+class TestTransferGeneration:
+    @pytest.fixture
+    def user(self, session):
+        u = f.UserFactory()
+        session.flush()
+        return u
+
+    def test_generate_retransfer(self, client: TestClient, user, bank_account):
+        client.assert_url_ok(url_for("finance.bank_account_retransfer", user_id=user.id))
+
+        formdata = serialize_formdata(
+            {
+                "bank_account": bank_account,
+                "user_name": user.name,
+                "iban": "DE61850503003120219540",
+                "bic": "OSDDDE81XXX",
+                "reason": "test",
+                "amount": 10,
+            }
+        )
+        client.assert_url_ok(
+            url_for("finance.bank_account_retransfer", user_id=user.id),
+            method="POST",
+            data=formdata,
+        )
+
+    def test_generate_transfer(self, client: TestClient, bank_account):
+        client.assert_ok("finance.bank_account_transfer")
+
+        formdata = serialize_formdata(
+            {
+                "bank_account": bank_account,
+                "owner": "Tester",
+                "iban": "DE61850503003120219540",
+                "bic": "OSDDDE81XXX",
+                "amount": 10,
+                "reference": "20260409",
+                "issue_id": "2026-V13",
+                "issue_name": "Feuerwehrauto",
+            }
+        )
+        client.assert_ok(
+            "finance.bank_account_transfer",
+            method="POST",
+            data=formdata,
+        )

--- a/tests/lib/test_finance.py
+++ b/tests/lib/test_finance.py
@@ -775,6 +775,4 @@ class TestTransfer:
         assert sepa_xml is not None
         assert len(sepa_xml) > 0
         with pytest.raises(ValueError):
-            generate_transfer_sepaxml(
-                bank_account, "owner", "2DE61", "OSDDDE81XXX", "test", 10
-            )
+            generate_transfer_sepaxml(bank_account, "owner", "2DE61", "OSDDDE81XXX", "test", 10)

--- a/tests/lib/test_finance.py
+++ b/tests/lib/test_finance.py
@@ -21,6 +21,7 @@ from pycroft.lib.finance import (
     take_actions_for_payment_in_default_users,
     get_activities_to_return,
     generate_activities_return_sepaxml,
+    generate_transfer_sepaxml,
 )
 from pycroft.model.finance import (
     Transaction,
@@ -35,6 +36,7 @@ from tests.factories.finance import (
     TransactionFactory,
     AccountFactory,
     BankAccountActivityFactory,
+    BankAccountFactory,
 )
 from tests.factories.user import UserFactory
 
@@ -762,3 +764,11 @@ class TestReturnNonAttributable:
         )
 
         generate_activities_return_sepaxml(get_activities_to_return(session))
+
+
+class TestTransfer:
+    def test_generate_transfer_sepa_xml(self, session: Session, utcnow):
+        bank_account = BankAccountFactory.build(iban="DE61850503003120219540")
+        generate_transfer_sepaxml(
+            bank_account, "owner", "DE61850503003120219540", "OSDDDE81XXX", "test", 10
+        )

--- a/tests/lib/test_finance.py
+++ b/tests/lib/test_finance.py
@@ -769,6 +769,12 @@ class TestReturnNonAttributable:
 class TestTransfer:
     def test_generate_transfer_sepa_xml(self, session: Session, utcnow):
         bank_account = BankAccountFactory.build(iban="DE61850503003120219540")
-        generate_transfer_sepaxml(
+        sepa_xml: bytes = generate_transfer_sepaxml(
             bank_account, "owner", "DE61850503003120219540", "OSDDDE81XXX", "test", 10
         )
+        assert sepa_xml is not None
+        assert len(sepa_xml) > 0
+        with pytest.raises(ValueError):
+            generate_transfer_sepaxml(
+                bank_account, "owner", "2DE61", "OSDDDE81XXX", "test", 10
+            )

--- a/web/blueprints/finance/__init__.py
+++ b/web/blueprints/finance/__init__.py
@@ -783,7 +783,7 @@ def bank_account_activities_return_do() -> ResponseReturnValue:
     )
 
 
-@bp.route('/transfer', defaults={'user_id': None}, methods=["GET", "POST"])
+@bp.route("/transfer", defaults={"user_id": None}, methods=["GET", "POST"])
 @bp.route("/transfer/<int:user_id>", methods=["GET", "POST"])
 @nav.navigate("Überweisung", icon="fa-wallet")
 def bank_account_transfer(user_id: int) -> ResponseReturnValue:
@@ -804,14 +804,14 @@ def bank_account_transfer(user_id: int) -> ResponseReturnValue:
 
         if user_id is None:
             issue_id: str = form.issue_id.data
-            reference: str = f"{form.reference.data} {issue_id} {form.issue_name.data}"
-            download_name: str = f"{issue_id}.xml"
+            sepa_reference = f"{form.reference.data} {issue_id} {form.issue_name.data}"
+            download_name = f"{issue_id}.xml"
         else:
-            reference: str = form.reference.data
-            download_name: str = f"retransfer-{user.id}-{datetime.now().date()}.xml"
+            sepa_reference = form.reference.data
+            download_name = f"retransfer-{user.id}-{datetime.now().date()}.xml"
 
         sepa_xml: bytes = generate_transfer_sepaxml(
-            bank_account, form.owner.data, form.iban.data, form.bic.data, reference, amount
+            bank_account, form.owner.data, form.iban.data, form.bic.data, sepa_reference, amount
         )
 
         return send_file(

--- a/web/blueprints/finance/__init__.py
+++ b/web/blueprints/finance/__init__.py
@@ -84,6 +84,7 @@ from pycroft.lib.finance import (
     get_accounts_by_type,
     get_last_import_date,
     get_last_membership_fee,
+    generate_transfer_sepaxml,
 )
 from pycroft.lib.finance.fints import get_fints_transactions, get_fints_client
 from pycroft.lib.finance.matching import UserMatching, AccountMatching
@@ -111,6 +112,8 @@ from web.blueprints.finance.forms import (
     BankAccountActivitiesImportManualForm,
     ConfirmPaymentReminderMail,
     FinTSTANForm,
+    BankAccountTransferForm,
+    BankAccountUserRetransferForm,
 )
 from web.blueprints.finance.tables import (
     FinanceTable,
@@ -780,6 +783,80 @@ def bank_account_activities_return_do() -> ResponseReturnValue:
     )
 
 
+@bp.route("/transfer", methods=["GET", "POST"])
+@nav.navigate("Überweisung", icon="fa-wallet")
+def bank_account_transfer() -> ResponseReturnValue:
+    form = BankAccountTransferForm()
+    form.bank_account.query = get_all_bank_accounts(session)
+
+    if form.validate_on_submit():
+        bank_account = form.bank_account.data
+        amount = form.amount.data
+        _ensure_decimal(amount)
+        issue_id: str = form.issue_id.data
+        reason: str = f"{form.reference.data} {issue_id} {form.issue_name.data}"
+
+        sepa_xml: bytes = generate_transfer_sepaxml(
+            bank_account, form.owner.data, form.iban.data, form.bic.data, reason, amount
+        )
+
+        return send_file(
+            BytesIO(sepa_xml),
+            as_attachment=True,
+            download_name=f"{issue_id}.xml",
+        )
+
+    form_args = {
+        "form": form,
+        "cancel_to": url_for(".bank_accounts_list"),
+        "submit_text": "Exportieren",
+    }
+
+    return render_template(
+        "generic_form.html",
+        page_title="Überweisung für Datei-Import",
+        form_args=form_args,
+        form=form,
+    )
+
+
+@bp.route("/transfer/<int:user_id>", methods=["GET", "POST"])
+def bank_account_retransfer(user_id: int) -> ResponseReturnValue:
+    user = _get_or_404(session, User, user_id)
+    reason: str = f"{user.id} Rückerstattung zu viel gezahlte Beiträge"
+    form = BankAccountUserRetransferForm(
+        user_name=user.name, reason=reason, amount=user.account.balance
+    )
+    form.bank_account.query = get_all_bank_accounts(session)
+
+    if form.validate_on_submit():
+        bank_account = form.bank_account.data
+        amount = form.amount.data
+        _ensure_decimal(amount)
+
+        sepa_xml: bytes = generate_transfer_sepaxml(
+            bank_account, form.user_name.data, form.iban.data, form.bic.data, reason, amount
+        )
+
+        return send_file(
+            BytesIO(sepa_xml),
+            as_attachment=True,
+            download_name=f"retransfer-{user.id}-{datetime.now().date()}.xml",
+        )
+
+    form_args = {
+        "form": form,
+        "cancel_to": url_for(".bank_accounts_list"),
+        "submit_text": "Exportieren",
+    }
+
+    return render_template(
+        "generic_form.html",
+        page_title="Rückerstattung für Datei-Import",
+        form_args=form_args,
+        form=form,
+    )
+
 
 class UserMatch(t.TypedDict):
     purpose: str
@@ -1438,11 +1515,6 @@ def transactions_all_json() -> ResponseReturnValue:
 def transactions_create() -> ResponseReturnValue:
     form = TransactionCreateForm()
 
-    def _ensure_decimal(v: t.Any) -> Decimal:
-        if isinstance(v, Decimal):
-            return v
-        abort(400, f"{v!r} is not a decimal value.")
-
     if form.validate_on_submit():
         splits = [
             (
@@ -1820,3 +1892,9 @@ def _get_or_404[TModel: ModelBase](session: Session, Model: type[TModel], pkey: 
     if obj is None:
         abort(404, f"Could not find {Model} with primary key {pkey}")
     return obj
+
+
+def _ensure_decimal(v: t.Any) -> Decimal:
+    if isinstance(v, Decimal):
+        return v
+    abort(400, f"{v!r} is not a decimal value.")

--- a/web/blueprints/finance/__init__.py
+++ b/web/blueprints/finance/__init__.py
@@ -112,8 +112,8 @@ from web.blueprints.finance.forms import (
     BankAccountActivitiesImportManualForm,
     ConfirmPaymentReminderMail,
     FinTSTANForm,
+    BankAccountIssueTransferForm,
     BankAccountTransferForm,
-    BankAccountUserRetransferForm,
 )
 from web.blueprints.finance.tables import (
     FinanceTable,
@@ -783,27 +783,41 @@ def bank_account_activities_return_do() -> ResponseReturnValue:
     )
 
 
-@bp.route("/transfer", methods=["GET", "POST"])
+@bp.route('/transfer', defaults={'user_id': None}, methods=["GET", "POST"])
+@bp.route("/transfer/<int:user_id>", methods=["GET", "POST"])
 @nav.navigate("Überweisung", icon="fa-wallet")
-def bank_account_transfer() -> ResponseReturnValue:
-    form = BankAccountTransferForm()
+def bank_account_transfer(user_id: int) -> ResponseReturnValue:
+    if user_id is None:
+        form = BankAccountIssueTransferForm()
+    else:
+        user = _get_or_404(session, User, user_id)
+        reference: str = f"{user.id} Rückerstattung zu viel gezahlte Beiträge"
+        form = BankAccountTransferForm(
+            owner=user.name, reference=reference, amount=user.account.balance
+        )
     form.bank_account.query = get_all_bank_accounts(session)
 
     if form.validate_on_submit():
         bank_account = form.bank_account.data
         amount = form.amount.data
         _ensure_decimal(amount)
-        issue_id: str = form.issue_id.data
-        reason: str = f"{form.reference.data} {issue_id} {form.issue_name.data}"
+
+        if user_id is None:
+            issue_id: str = form.issue_id.data
+            reference: str = f"{form.reference.data} {issue_id} {form.issue_name.data}"
+            download_name: str = f"{issue_id}.xml"
+        else:
+            reference: str = form.reference.data
+            download_name: str = f"retransfer-{user.id}-{datetime.now().date()}.xml"
 
         sepa_xml: bytes = generate_transfer_sepaxml(
-            bank_account, form.owner.data, form.iban.data, form.bic.data, reason, amount
+            bank_account, form.owner.data, form.iban.data, form.bic.data, reference, amount
         )
 
         return send_file(
             BytesIO(sepa_xml),
             as_attachment=True,
-            download_name=f"{issue_id}.xml",
+            download_name=download_name,
         )
 
     form_args = {
@@ -815,44 +829,6 @@ def bank_account_transfer() -> ResponseReturnValue:
     return render_template(
         "generic_form.html",
         page_title="Überweisung für Datei-Import",
-        form_args=form_args,
-        form=form,
-    )
-
-
-@bp.route("/transfer/<int:user_id>", methods=["GET", "POST"])
-def bank_account_retransfer(user_id: int) -> ResponseReturnValue:
-    user = _get_or_404(session, User, user_id)
-    reason: str = f"{user.id} Rückerstattung zu viel gezahlte Beiträge"
-    form = BankAccountUserRetransferForm(
-        user_name=user.name, reason=reason, amount=user.account.balance
-    )
-    form.bank_account.query = get_all_bank_accounts(session)
-
-    if form.validate_on_submit():
-        bank_account = form.bank_account.data
-        amount = form.amount.data
-        _ensure_decimal(amount)
-
-        sepa_xml: bytes = generate_transfer_sepaxml(
-            bank_account, form.user_name.data, form.iban.data, form.bic.data, reason, amount
-        )
-
-        return send_file(
-            BytesIO(sepa_xml),
-            as_attachment=True,
-            download_name=f"retransfer-{user.id}-{datetime.now().date()}.xml",
-        )
-
-    form_args = {
-        "form": form,
-        "cancel_to": url_for(".bank_accounts_list"),
-        "submit_text": "Exportieren",
-    }
-
-    return render_template(
-        "generic_form.html",
-        page_title="Rückerstattung für Datei-Import",
         form_args=form_args,
         form=form,
     )

--- a/web/blueprints/finance/forms.py
+++ b/web/blueprints/finance/forms.py
@@ -4,6 +4,7 @@
 import datetime
 
 from flask_wtf import FlaskForm as Form
+from schwifty import IBAN, BIC
 from wtforms import Form as WTForm, ValidationError, Field
 from wtforms.validators import DataRequired, NumberRange, Optional, \
     InputRequired
@@ -190,6 +191,23 @@ class BankAccountTransferForm(Form):
         validators=[DataRequired()],
     )
 
+    def validate_iban(self, field: Field) -> None:
+        try:
+            IBAN(field.data)
+        except ValueError:
+            raise ValidationError(gettext("Invalid IBAN."))
+
+    def validate_bic(self, field: Field) -> None:
+        try:
+            BIC(field.data)
+        except ValueError:
+            raise ValidationError(gettext("Invalid BIC."))
+
+    def validate_amount(self, field: Field) -> None:
+        cents = field.data.shift(2)
+        if cents == 0 or cents != int(cents):
+            raise ValidationError(gettext("Invalid value."))
+
 
 class BankAccountUserRetransferForm(Form):
     bank_account = QuerySelectField("Bankkonto", get_label="name", validators=[DataRequired()])
@@ -198,6 +216,23 @@ class BankAccountUserRetransferForm(Form):
     bic = TextField("BIC", validators=[DataRequired()])
     reason = static(StringField("Verwendungszweck"))
     amount = MoneyField("Wert", validators=[DataRequired(message=gettext("Invalid value."))])
+
+    def validate_iban(self, field: Field) -> None:
+        try:
+            IBAN(field.data)
+        except ValueError:
+            raise ValidationError(gettext("Invalid IBAN."))
+
+    def validate_bic(self, field: Field) -> None:
+        try:
+            BIC(field.data)
+        except ValueError:
+            raise ValidationError(gettext("Invalid BIC."))
+
+    def validate_amount(self, field: Field) -> None:
+        cents = field.data.shift(2)
+        if cents == 0 or cents != int(cents):
+            raise ValidationError(gettext("Invalid value."))
 
 
 class ActivityMatchForm(Form):

--- a/web/blueprints/finance/forms.py
+++ b/web/blueprints/finance/forms.py
@@ -181,7 +181,26 @@ class BankAccountTransferForm(Form):
     iban = TextField("IBAN", validators=[DataRequired()])
     bic = TextField("BIC", validators=[DataRequired()])
     amount = MoneyField("Wert", validators=[DataRequired(message=gettext("Invalid value."))])
-    reference = TextField("Rechnungsreferenz", validators=[DataRequired()])
+    reference = TextField("Verwendungszweck", validators=[DataRequired()])
+    def validate_iban(self, field: Field) -> None:
+        try:
+            IBAN(field.data)
+        except ValueError as err:
+            raise ValidationError(gettext("Invalid IBAN.")) from err
+
+    def validate_bic(self, field: Field) -> None:
+        try:
+            BIC(field.data)
+        except ValueError as err:
+            raise ValidationError(gettext("Invalid BIC.")) from err
+
+    def validate_amount(self, field: Field) -> None:
+        cents = field.data.shift(2)
+        if cents < 1 or cents != int(cents):
+            raise ValidationError(gettext("Invalid value."))
+
+
+class BankAccountIssueTransferForm(BankAccountTransferForm):
     issue_id = TextField(
         "Vorgangsnummer", render_kw={"placeholder": "2026-X00"}, validators=[DataRequired()]
     )
@@ -190,49 +209,6 @@ class BankAccountTransferForm(Form):
         render_kw={"placeholder": "Überweisung"},
         validators=[DataRequired()],
     )
-
-    def validate_iban(self, field: Field) -> None:
-        try:
-            IBAN(field.data)
-        except ValueError as err:
-            raise ValidationError(gettext("Invalid IBAN.")) from err
-
-    def validate_bic(self, field: Field) -> None:
-        try:
-            BIC(field.data)
-        except ValueError as err:
-            raise ValidationError(gettext("Invalid BIC.")) from err
-
-    def validate_amount(self, field: Field) -> None:
-        cents = field.data.shift(2)
-        if cents == 0 or cents != int(cents):
-            raise ValidationError(gettext("Invalid value."))
-
-
-class BankAccountUserRetransferForm(Form):
-    bank_account = QuerySelectField("Bankkonto", get_label="name", validators=[DataRequired()])
-    user_name = TextField("Kontoinhaber", validators=[DataRequired()])
-    iban = TextField("IBAN", validators=[DataRequired()])
-    bic = TextField("BIC", validators=[DataRequired()])
-    reason = static(StringField("Verwendungszweck"))
-    amount = MoneyField("Wert", validators=[DataRequired(message=gettext("Invalid value."))])
-
-    def validate_iban(self, field: Field) -> None:
-        try:
-            IBAN(field.data)
-        except ValueError as err:
-            raise ValidationError(gettext("Invalid IBAN.")) from err
-
-    def validate_bic(self, field: Field) -> None:
-        try:
-            BIC(field.data)
-        except ValueError as err:
-            raise ValidationError(gettext("Invalid BIC.")) from err
-
-    def validate_amount(self, field: Field) -> None:
-        cents = field.data.shift(2)
-        if cents == 0 or cents != int(cents):
-            raise ValidationError(gettext("Invalid value."))
 
 
 class ActivityMatchForm(Form):

--- a/web/blueprints/finance/forms.py
+++ b/web/blueprints/finance/forms.py
@@ -174,6 +174,32 @@ class TransactionCreateForm(Form):
             raise ValidationError("Buchung ist nicht ausgeglichen.")
 
 
+class BankAccountTransferForm(Form):
+    bank_account = QuerySelectField("Bankkonto", get_label="name", validators=[DataRequired()])
+    owner = TextField("Kontoinhaber", validators=[DataRequired()])
+    iban = TextField("IBAN", validators=[DataRequired()])
+    bic = TextField("BIC", validators=[DataRequired()])
+    amount = MoneyField("Wert", validators=[DataRequired(message=gettext("Invalid value."))])
+    reference = TextField("Rechnungsreferenz", validators=[DataRequired()])
+    issue_id = TextField(
+        "Vorgangsnummer", render_kw={"placeholder": "2026-X00"}, validators=[DataRequired()]
+    )
+    issue_name = TextField(
+        "Vorgangsbeschreibung",
+        render_kw={"placeholder": "Überweisung"},
+        validators=[DataRequired()],
+    )
+
+
+class BankAccountUserRetransferForm(Form):
+    bank_account = QuerySelectField("Bankkonto", get_label="name", validators=[DataRequired()])
+    user_name = TextField("Kontoinhaber", validators=[DataRequired()])
+    iban = TextField("IBAN", validators=[DataRequired()])
+    bic = TextField("BIC", validators=[DataRequired()])
+    reason = static(StringField("Verwendungszweck"))
+    amount = MoneyField("Wert", validators=[DataRequired(message=gettext("Invalid value."))])
+
+
 class ActivityMatchForm(Form):
     pass
 

--- a/web/blueprints/finance/forms.py
+++ b/web/blueprints/finance/forms.py
@@ -182,6 +182,7 @@ class BankAccountTransferForm(Form):
     bic = TextField("BIC", validators=[DataRequired()])
     amount = MoneyField("Wert", validators=[DataRequired(message=gettext("Invalid value."))])
     reference = TextField("Verwendungszweck", validators=[DataRequired()])
+
     def validate_iban(self, field: Field) -> None:
         try:
             IBAN(field.data)

--- a/web/blueprints/finance/forms.py
+++ b/web/blueprints/finance/forms.py
@@ -194,14 +194,14 @@ class BankAccountTransferForm(Form):
     def validate_iban(self, field: Field) -> None:
         try:
             IBAN(field.data)
-        except ValueError:
-            raise ValidationError(gettext("Invalid IBAN."))
+        except ValueError as err:
+            raise ValidationError(gettext("Invalid IBAN.")) from err
 
     def validate_bic(self, field: Field) -> None:
         try:
             BIC(field.data)
-        except ValueError:
-            raise ValidationError(gettext("Invalid BIC."))
+        except ValueError as err:
+            raise ValidationError(gettext("Invalid BIC.")) from err
 
     def validate_amount(self, field: Field) -> None:
         cents = field.data.shift(2)
@@ -220,14 +220,14 @@ class BankAccountUserRetransferForm(Form):
     def validate_iban(self, field: Field) -> None:
         try:
             IBAN(field.data)
-        except ValueError:
-            raise ValidationError(gettext("Invalid IBAN."))
+        except ValueError as err:
+            raise ValidationError(gettext("Invalid IBAN.")) from err
 
     def validate_bic(self, field: Field) -> None:
         try:
             BIC(field.data)
-        except ValueError:
-            raise ValidationError(gettext("Invalid BIC."))
+        except ValueError as err:
+            raise ValidationError(gettext("Invalid BIC.")) from err
 
     def validate_amount(self, field: Field) -> None:
         cents = field.data.shift(2)

--- a/web/templates/user/_user_show_basedata.html
+++ b/web/templates/user/_user_show_basedata.html
@@ -163,7 +163,7 @@
         {% endif %}
         <div class="col-md-6 action-button">
           <a role="button" class="btn btn-secondary btn-sq"
-             href="{{ url_for("finance.bank_account_retransfer", user_id=user.id) }}"
+             href="{{ url_for("finance.bank_account_transfer", user_id=user.id) }}"
              hint="Rücküberweisung generieren">
             <span class="badge rounded-pill bg-light text-dark"><span
                 class="fa fa-wallet"></span><span

--- a/web/templates/user/_user_show_basedata.html
+++ b/web/templates/user/_user_show_basedata.html
@@ -161,23 +161,16 @@
                   class="fa fa-home"></span></span><br/>Einziehen</a>
           </div>
         {% endif %}
-        {% if is_blocked %}
-          <div class="col-md-6 action-button">
-            <a class="btn btn-warning btn-sq"
-               href="{{ url_for(".unblock", user_id=user.id) }}">
-              <span class="badge rounded-pill bg-light text-dark"><span
-                  class="fa fa-ok"></span><span
-                  class="glyphicon"></span></span><br/>Entsperren</a>
-          </div>
-        {% else %}
-          <div class="col-md-6 action-button">
-            <a class="btn btn-warning btn-sq"
-               href="{{ url_for(".block", user_id=user.id) }}">
-              <span class="badge rounded-pill bg-light text-dark"><span
-                  class="fa fa-times"></span><span
-                  class="glyphicon"></span></span><br/>Sperren</a>
-          </div>
-        {% endif %}
+        <div class="col-md-6 action-button">
+          <a role="button" class="btn btn-secondary btn-sq"
+             href="{{ url_for("finance.bank_account_retransfer", user_id=user.id) }}"
+             hint="Rücküberweisung generieren">
+            <span class="badge rounded-pill bg-light text-dark"><span
+                class="fa fa-wallet"></span><span
+                class="glyphicon"></span></span>
+            <br/>Rücküberweisung
+          </a>
+        </div>
         <div class="col-md-6 action-button">
           <a role="button" class="btn btn-danger btn-sq"
              href="{{ url_for(".reset_password", user_id=user.id) }}"
@@ -188,6 +181,23 @@
             <br/>Passwort Reset
           </a>
         </div>
+        {% if is_blocked %}
+          <div class="col-md-12 action-button">
+            <a class="btn btn-warning btn-sq"
+               href="{{ url_for(".unblock", user_id=user.id) }}">
+              <span class="badge rounded-pill bg-light text-dark"><span
+                  class="fa fa-ok"></span><span
+                  class="glyphicon"></span></span><br/>Entsperren</a>
+          </div>
+        {% else %}
+          <div class="col-md-12 action-button">
+            <a class="btn btn-warning btn-sq"
+               href="{{ url_for(".block", user_id=user.id) }}">
+              <span class="badge rounded-pill bg-light text-dark"><span
+                  class="fa fa-times"></span><span
+                  class="glyphicon"></span></span><br/>Sperren</a>
+          </div>
+        {% endif %}
         <div class="col-md-12 action-button">
           <a role="button" class="btn btn-info btn-sq"
              href="{{ url_for(".reset_wifi_password", user_id=user.id) }}"


### PR DESCRIPTION
Generate xml-files for:
- user retransfer ("Rücküberweisung")
- invoice payment

Why? Our new bank sometimes loses the payment reference in manual transfers. This error does not occur with an uploaded transfer.